### PR TITLE
[FEAT] 메인 뷰 강아지 관련 기능 구현 #15

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,13 +34,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # Firebase 설정 json 파일 생성
+      - name: Make firebase json file
+        run: |
+          mkdir -p ./src/main/resources/firebase
+          echo "${{ secrets.FIREBASE_ADMIN_SDK_BASE64 }}" | base64 -d > ./src/main/resources/firebase/puppymode-53d9a-firebase-adminsdk-myzbc-7e65f856a6.json
+
       # yml 파일 생성
       - name: Make application.yml
         run: |
           mkdir -p ./src/main/resources
-          cd ./src/main/resources
-          touch ./application.yml
-          echo "${{ secrets.APPLICATION_YML }}" > ./application.yml
+          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
         shell: bash
 
       # Spring Boot 어플리케이션 Build

--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -20,7 +20,13 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER404", "해당 ID를 가진 사용자를 찾을 수 없습니다."),
 
     // For test
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
+
+    // 강아지 관련 예외 처리
+    PUPPY_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY404", "해당 ID를 가진 강아지를 찾을 수 없습니다."),
+    UNAUTHORIZED_PUPPY_ACCESS(HttpStatus.UNAUTHORIZED, "PUPPY401", "강아지에 대한 접근 권한이 없습니다.")
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
+++ b/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
@@ -1,0 +1,36 @@
+package umc.puppymode.converter;
+
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+public class MainPuppyConverter {
+
+    public static MainPuppyResDTO.RandomPuppyViewDTO toRandomPuppyViewDTO(String type, String imageUrl) {
+        return MainPuppyResDTO.RandomPuppyViewDTO.builder()
+                .puppyType(type)
+                .puppyImageUrl(imageUrl)
+                .build();
+    }
+
+    public static MainPuppyResDTO.UserPuppyViewDTO toUserPuppyViewDTO(Puppy puppy) {
+        return MainPuppyResDTO.UserPuppyViewDTO.builder()
+                .puppyId(puppy.getPuppyId())
+                .puppyName(puppy.getPuppyName())
+                .level(puppy.getPuppyLevel().getPuppyLevel())
+                .levelName(puppy.getPuppyLevel().getLevelName())
+                .imageUrl(puppy.getPuppyImageUrl())
+                .levelMinExp(puppy.getPuppyLevel().getLevelMinExp())
+                .levelMaxExp(puppy.getPuppyLevel().getLevelMaxEXP())
+                .puppyExp(puppy.getPuppyExp())
+                .build();
+    }
+
+    public static MainPuppyResDTO.PlayResDTO toPlayResDTO(Puppy puppy) {
+        return MainPuppyResDTO.PlayResDTO.builder()
+                .level(puppy.getPuppyLevel().getPuppyLevel())
+                .levelMinExp(puppy.getPuppyLevel().getLevelMinExp())
+                .levelMaxExp(puppy.getPuppyLevel().getLevelMaxEXP())
+                .puppyExp(puppy.getPuppyExp())
+                .build();
+    }
+}

--- a/src/main/java/umc/puppymode/domain/Puppy.java
+++ b/src/main/java/umc/puppymode/domain/Puppy.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import umc.puppymode.domain.common.BaseEntity;
 import umc.puppymode.domain.enums.CustomizingItem;
-import umc.puppymode.domain.enums.PuppyType;
 
 @Entity
 @Getter
@@ -20,12 +19,25 @@ public class Puppy extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Enumerated(EnumType.STRING)
-    private PuppyType puppyType;
+    @ManyToOne
+    @JoinColumn(name = "puppy_level_id")
+    private PuppyLevel puppyLevel;
 
     private String puppyImageUrl;
     private String puppyName;
+    private Integer puppyExp;
 
     @Enumerated(EnumType.STRING)
     private CustomizingItem puppyItem;
+
+    public void updatePuppyName(String puppyName) {
+        this.puppyName = puppyName;
+    }
+
+    public void updatePuppyExp(Integer puppyExp) {
+        this.puppyExp += puppyExp;
+    }
+
+    // Exp 변경 시마다 puppyLevel.MaxExp 값을 넘는지 체크한 후, 넘는다면 puppyLevel 을 바꿔주는 메서드 추가하면 좋을 것 같음.
+    // updatePuppyExp 메서드 내부에, puppyExp를 증가시킨 후 해당 메서드를 넣어주면 될듯.
 }

--- a/src/main/java/umc/puppymode/domain/Puppy.java
+++ b/src/main/java/umc/puppymode/domain/Puppy.java
@@ -15,7 +15,7 @@ public class Puppy extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long puppyId;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/umc/puppymode/domain/Puppy.java
+++ b/src/main/java/umc/puppymode/domain/Puppy.java
@@ -36,8 +36,11 @@ public class Puppy extends BaseEntity {
 
     public void updatePuppyExp(Integer puppyExp) {
         this.puppyExp += puppyExp;
+        if (this.puppyExp >= puppyLevel.getLevelMaxEXP()) {
+            PuppyLevel nextLevel = puppyLevel.getNextLevel();
+            if (nextLevel != null) {
+                this.puppyLevel = nextLevel;
+            } // nextLevel이 null인 경우 현재 레벨이 최대 레벨
+        }
     }
-
-    // Exp 변경 시마다 puppyLevel.MaxExp 값을 넘는지 체크한 후, 넘는다면 puppyLevel 을 바꿔주는 메서드 추가하면 좋을 것 같음.
-    // updatePuppyExp 메서드 내부에, puppyExp를 증가시킨 후 해당 메서드를 넣어주면 될듯.
 }

--- a/src/main/java/umc/puppymode/domain/PuppyLevel.java
+++ b/src/main/java/umc/puppymode/domain/PuppyLevel.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import umc.puppymode.domain.common.BaseEntity;
+import umc.puppymode.domain.enums.PuppyType;
 
 @Entity
 @Getter
@@ -14,10 +15,12 @@ public class PuppyLevel extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long puppyLevelId;
 
-    @ManyToOne
-    @JoinColumn(name = "puppy_id")
-    private Puppy puppy;
+    @Enumerated(EnumType.STRING)
+    private PuppyType puppyType;
 
     private Integer puppyLevel;
-    private String puppyGrowth;
+    private String levelName;
+    private String levelImageUrl;
+    private Integer levelMinExp;
+    private Integer levelMaxEXP;
 }

--- a/src/main/java/umc/puppymode/domain/PuppyLevel.java
+++ b/src/main/java/umc/puppymode/domain/PuppyLevel.java
@@ -18,6 +18,10 @@ public class PuppyLevel extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PuppyType puppyType;
 
+    @ManyToOne
+    @JoinColumn(name = "next_level_id")
+    private PuppyLevel nextLevel;
+
     private Integer puppyLevel;
     private String levelName;
     private String levelImageUrl;

--- a/src/main/java/umc/puppymode/domain/User.java
+++ b/src/main/java/umc/puppymode/domain/User.java
@@ -20,5 +20,9 @@ public class User extends BaseEntity {
     private String password;
     private Integer points;
     private Boolean receiveNotifications;
+
+    public void updatePoints(Integer points) {
+        this.points += points;
+    }
 }
 

--- a/src/main/java/umc/puppymode/domain/enums/PuppyType.java
+++ b/src/main/java/umc/puppymode/domain/enums/PuppyType.java
@@ -1,28 +1,19 @@
 package umc.puppymode.domain.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum PuppyType {
-    // 포메라니안 타입
-    POMERANIAN_BABY("아기사자 포메라니안"),
-    POMERANIAN_YOUTH("꼬마사자 포메라니안"),
-    POMERANIAN_ADULT("작은사자 포메라니안"),
 
-    // 웰시코기 타입
-    WELSH_CORGI_BABY("땅콩 웰시코기"),
-    WELSH_CORGI_YOUTH("빵떡 웰시코기"),
-    WELSH_CORGI_ADULT("핫도그 웰시코기"),
+    POMERANIAN("포메라니안", "https://example.com/pomeranian_baby.jpg"),
+    WELSH_CORGI("웰시코기", "https://example.com/welshCorgi_baby.jpg"),
+    BICHON("비숑 프리제", "https://example.com/bichon_baby.jpg");
 
-    // 비숑 타입
-    BICHON_BABY("눈송이 비숑"),
-    BICHON_YOUTH("솜사탕 비숑"),
-    BICHON_ADULT("털뭉치 비숑");
+    private final String type;
+    private final String imageUrl;
 
-    private final String description;
-
-    PuppyType(String description) {
-        this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
+    PuppyType(String type, String imageUrl) {
+        this.type = type;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/umc/puppymode/repository/PuppyRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyRepository.java
@@ -1,0 +1,14 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import umc.puppymode.domain.Puppy;
+
+import java.util.Optional;
+
+public interface PuppyRepository extends JpaRepository<Puppy, Long> {
+
+    @Query("SELECT p FROM Puppy p WHERE p.user.userId = :userId")
+    Optional<Puppy> findByUserId(Long userId);
+
+}

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
@@ -1,0 +1,13 @@
+package umc.puppymode.service.MainPuppyService;
+
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+public interface MainPuppyCommandService {
+    
+    // 랜덤으로 강아지를 선택
+    MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy();
+    // 강아지의 이름을 수정
+    String updatePuppyName(Long puppyId, String newPuppyName);
+    // 강아지 놀아주기 실행
+    MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId, Long puppyId);
+}

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
@@ -1,0 +1,66 @@
+package umc.puppymode.service.MainPuppyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.handler.TempHandler;
+import umc.puppymode.converter.MainPuppyConverter;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.User;
+import umc.puppymode.domain.enums.PuppyType;
+import umc.puppymode.repository.PuppyRepository;
+import umc.puppymode.repository.UserRepository;
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+import java.util.Random;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MainPuppyCommandServiceImpl implements MainPuppyCommandService {
+
+    private final PuppyRepository puppyRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    // 랜덤으로 강아지를 선택
+    public MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy() {
+
+        Random RANDOM = new Random();
+        PuppyType[] types = PuppyType.values();
+        PuppyType type = types[RANDOM.nextInt(types.length)];
+
+        // 강아지 종의 이름과, 해당 종의 레벨 1 이미지를 ResponseDTO로 만들어 반환
+        return MainPuppyConverter.toRandomPuppyViewDTO(type.getType(), type.getImageUrl());
+    }
+
+    @Override
+    // 강아지의 이름을 수정
+    public String updatePuppyName(Long puppyId, String newPuppyName) {
+
+        Puppy puppy = puppyRepository.findById(puppyId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
+        puppy.updatePuppyName(newPuppyName);
+
+        return puppy.getPuppyName();
+    }
+
+    @Override
+    // 강아지 놀아주기 실행
+    public MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId, Long puppyId) {
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
+        Puppy puppy = puppyRepository.findById(puppyId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
+        // 강아지가 현재 사용자의 강아지가 아닌 경우 에러 발생
+        if (!userId.equals(puppy.getUser().getUserId())) {
+            throw new TempHandler(ErrorStatus.UNAUTHORIZED_PUPPY_ACCESS);
+        }
+        // 사용자 포인트 10p 증가
+        user.updatePoints(10);
+        // 현재 레벨의 전체 경험치의 5% 만큼의 경험치 계산
+        Integer fivePercentExp = (puppy.getPuppyLevel().getLevelMaxEXP() - puppy.getPuppyLevel().getLevelMinExp()) * 5 / 100;
+        puppy.updatePuppyExp(fivePercentExp); // 이 내부에서 레벨 업도 진행해준다고 가정
+
+        return MainPuppyConverter.toPlayResDTO(puppy);
+    }
+}

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryService.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryService.java
@@ -1,0 +1,9 @@
+package umc.puppymode.service.MainPuppyService;
+
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+public interface MainPuppyQueryService {
+
+    // 사용자의 강아지 정보를 조회
+    MainPuppyResDTO.UserPuppyViewDTO getUserPuppy(Long userId);
+}

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryServiceImpl.java
@@ -1,0 +1,31 @@
+package umc.puppymode.service.MainPuppyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.handler.TempHandler;
+import umc.puppymode.converter.MainPuppyConverter;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.repository.PuppyRepository;
+import umc.puppymode.repository.UserRepository;
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MainPuppyQueryServiceImpl implements MainPuppyQueryService {
+
+    private final PuppyRepository puppyRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    // 사용자의 강아지 정보를 조회
+    public MainPuppyResDTO.UserPuppyViewDTO getUserPuppy(Long userId) {
+
+        userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
+        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
+
+        return MainPuppyConverter.toUserPuppyViewDTO(puppy);
+    }
+}

--- a/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
+++ b/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
@@ -1,0 +1,60 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.MainPuppyService.MainPuppyCommandService;
+import umc.puppymode.service.MainPuppyService.MainPuppyQueryService;
+import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/puppies")
+public class MainPuppyController {
+
+    private final MainPuppyCommandService mainPuppyCommandService;
+    private final MainPuppyQueryService mainPuppyQueryService;
+
+    @PostMapping
+    @Operation(summary = "강아지 랜덤 선택 API", description = "강아지를 랜덤으로 선택하는 API입니다.")
+    public ApiResponse<MainPuppyResDTO.RandomPuppyViewDTO> getRandomPuppy() {
+
+        MainPuppyResDTO.RandomPuppyViewDTO randomPuppyViewDTO = mainPuppyCommandService.getRandomPuppy();
+        return ApiResponse.onSuccess(randomPuppyViewDTO);
+    }
+
+    // 추후에 유저 시큐리티 부분 구현되면, @CurrentUser와 같은 AuthUser를 사용하여 강아지 객체를 찾도록 수정 예정
+    @GetMapping
+    @Operation(summary = "사용자 강아지 정보 조회 API", description = "사용자의 강아지 정보를 조회하는 API입니다.")
+    public ApiResponse<MainPuppyResDTO.UserPuppyViewDTO> getUserPuppy(
+            @RequestParam Long userId) {
+
+        MainPuppyResDTO.UserPuppyViewDTO userPuppyViewDTO = mainPuppyQueryService.getUserPuppy(userId);
+        return ApiResponse.onSuccess(userPuppyViewDTO);
+    }
+
+    // 이 api 역시 추후에 puppyId가 아닌 @CurrentUser 등을 사용하여 수정할 강아지 객체를 찾도록 수정 예정
+    @PatchMapping
+    @Operation(summary = "강아지 이름 수정 API", description = "강아지의 이름을 수정하는 API입니다.")
+    public ApiResponse<String> updatePuppyName(
+            @RequestParam Long puppyId,
+            @RequestParam String newPuppyName) {
+
+        String updatedPuppyName = mainPuppyCommandService.updatePuppyName(puppyId, newPuppyName);
+        return ApiResponse.onSuccess(updatedPuppyName);
+    }
+
+    // 이 api도 @CurrentUser 등을 사용하여 유저 정보를 얻도록 수정 예정
+    @PostMapping("/play")
+    @Operation(summary = "강아지 놀아주기 API", description = "강아지 놀아주기를 실행하는 API입니다.")
+    public ApiResponse<MainPuppyResDTO.PlayResDTO> playWithPuppy(
+            @RequestParam Long userId,
+            @RequestParam Long puppyId) {
+
+        MainPuppyResDTO.PlayResDTO playResDTO = mainPuppyCommandService.platWithPuppy(userId, puppyId);
+
+        // 낙관적 업데이트 사용 시, 현재 리턴값인 playResDTO 내부의 값을 사용하여 유효성 판단
+        return ApiResponse.onSuccess(playResDTO);
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/MainPuppyDTO/MainPuppyResDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/MainPuppyDTO/MainPuppyResDTO.java
@@ -1,0 +1,40 @@
+package umc.puppymode.web.dto.MainPuppyDTO;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class MainPuppyResDTO {
+
+    @Getter
+    @Builder
+    // 온보딩 화면에 보여지는 랜덤선택된 강아지의 정보
+    public static class RandomPuppyViewDTO {
+        private String puppyType;
+        private String puppyImageUrl;
+    }
+
+    @Getter
+    @Builder
+    // 메인 화면에 보여지는 사용자의 강아지 정보
+    public static class UserPuppyViewDTO {
+        private Long puppyId;
+        private String puppyName;
+        private Integer level;
+        private String levelName;
+        private String imageUrl;
+        private Integer levelMinExp; // 해당 레벨의 최소 경험치 값 (퍼센트 계산에 사용)
+        private Integer levelMaxExp; // 해당 레벨의 최대 경험치 값 (퍼센트 계산 및 레벨업에 사용)
+        private Integer puppyExp; // 강아지의 현재 경험치 값
+        // customization DTO는 커스텀 관련 기능이 추가된 후 넣을 예정입니다.
+    }
+
+    @Getter
+    @Builder
+    // 강아지 놀아주기 실행 후 반환되는 값
+    public static class PlayResDTO {
+        private Integer level;
+        private Integer levelMinExp; // 해당 레벨의 최소 경험치 값 (퍼센트 계산에 사용)
+        private Integer levelMaxExp; // 해당 레벨의 최대 경험치 값 (퍼센트 계산 및 레벨업에 사용)
+        private Integer puppyExp; // 강아지의 현재 경험치 값
+    }
+}


### PR DESCRIPTION
# 🚀 개요
- 메인 뷰 강아지와 관련된 api 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #15 

## ⏳ 작업 내용
- 강아지 랜덤 선택
- 사용자 강아지 정보 조회
- 강아지 이름 수정
- 강아지 놀아주기

시큐리티나 커스텀 부분에서 구현하지 않은 부분은 주석으로 표기해 두었습니다.

커스텀 강아지 기능 담당하신 분의 코드와 충돌이 생길 수도 있을 것 같아, Repository를 제외한 모든 생성파일은 일단 MainPuppy~ 로 작성해 두었습니다...!! 

주석으로 작성해둔 몇가지 혼잣말을 지우지 못한 것을 방금 알아차렸는데, 이는 코드리뷰&수정 후 머지 날리기 전에 한번에 지우도록 하겠습니다.😅

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
