### PR TITLE
[FEAT] 강아지 꾸미기 관련 API 구현 #16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 jar {

--- a/src/main/java/umc/puppymode/domain/PuppyItem.java
+++ b/src/main/java/umc/puppymode/domain/PuppyItem.java
@@ -1,0 +1,27 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import umc.puppymode.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class PuppyItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long itemId;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private PuppyItemCategory category; // 카테고리 ID
+
+    private String itemName; // 아이템 이름
+    private String imageUrl; // 아이템 이미지 URL
+    private Integer price; // 아이템 가격
+}

--- a/src/main/java/umc/puppymode/domain/PuppyItemCategory.java
+++ b/src/main/java/umc/puppymode/domain/PuppyItemCategory.java
@@ -1,0 +1,19 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import umc.puppymode.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@Setter
+public class PuppyItemCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    private String categoryName; // 카테고리 이름
+}
+

--- a/src/main/java/umc/puppymode/domain/User.java
+++ b/src/main/java/umc/puppymode/domain/User.java
@@ -6,6 +6,9 @@ import lombok.Getter;
 import lombok.Setter;
 import umc.puppymode.domain.common.BaseEntity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter

--- a/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
+++ b/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
@@ -1,0 +1,32 @@
+package umc.puppymode.domain.mapping;
+
+import lombok.Getter;
+import lombok.Setter;
+import jakarta.persistence.*;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyItem;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class PuppyCustomization {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long customizationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "puppy_id")
+    private Puppy puppy;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private PuppyItem puppyItem;
+
+    private Boolean isEquipped; // 아이템 장착 여부
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
@@ -1,0 +1,13 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.mapping.PuppyCustomization;
+
+import java.util.Optional;
+
+public interface PuppyCustomizationRepository extends JpaRepository<PuppyCustomization, Long> {
+    boolean existsByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
+    Optional<PuppyCustomization> findByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
+}

--- a/src/main/java/umc/puppymode/repository/PuppyItemCategoryRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyItemCategoryRepository.java
@@ -1,0 +1,8 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import umc.puppymode.domain.PuppyItemCategory;
+
+public interface PuppyItemCategoryRepository extends JpaRepository<PuppyItemCategory, Long> {
+}

--- a/src/main/java/umc/puppymode/repository/PuppyItemRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyItemRepository.java
@@ -1,0 +1,14 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.PuppyItem;
+
+import java.util.List;
+
+public interface PuppyItemRepository extends JpaRepository<PuppyItem, Long> {
+    // 특정 카테고리의 아이템 수를 계산
+    Long countByCategory_CategoryId(Long categoryId);
+
+    // 특정 카테고리의 모든 아이템 조회
+    List<PuppyItem> findAllByCategory_CategoryId(Long categoryId);
+}

--- a/src/main/java/umc/puppymode/repository/PuppyRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyRepository.java
@@ -1,0 +1,11 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.User;
+
+import java.util.Optional;
+
+public interface PuppyRepository extends JpaRepository<Puppy, Long> {
+    Optional<Puppy> findByUser(User user);
+}

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
@@ -1,0 +1,15 @@
+package umc.puppymode.service.PuppyService;
+
+import umc.puppymode.domain.User;
+import umc.puppymode.web.dto.ItemCategoryResponseDto;
+import umc.puppymode.web.dto.ItemResponseDto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PuppyItemService {
+    Map<String, Object> getAllCategories();
+    Map<String, Object> getItemsByCategory(Long categoryId);
+    Map<String, Object> purchaseItem(Long categoryId, Long itemId, User user);
+    Map<String, Object> equipItem(Long categoryId, Long itemId, User user);
+}

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -1,0 +1,154 @@
+package umc.puppymode.service.PuppyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.PuppyItemCategory;
+import umc.puppymode.domain.mapping.PuppyCustomization;
+import umc.puppymode.repository.*;
+import umc.puppymode.web.dto.EquippedItemInfoDTO;
+import umc.puppymode.web.dto.ItemCategoryResponseDto;
+import umc.puppymode.web.dto.ItemResponseDto;
+import umc.puppymode.domain.User;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PuppyItemServiceImpl implements PuppyItemService {
+
+    private final PuppyItemCategoryRepository categoryRepository;
+    private final PuppyItemRepository itemRepository;
+    private final UserRepository userRepository;
+    private final PuppyCustomizationRepository puppyCustomizationRepository;
+    private final PuppyRepository puppyRepository;
+
+    @Override
+    public Map<String, Object> getAllCategories() {
+        // 전체 카테고리 수
+        Long totalCategoryCount = categoryRepository.count();
+
+        List<ItemCategoryResponseDto> categories = categoryRepository.findAll().stream()
+                .map(category -> new ItemCategoryResponseDto(
+                        category.getCategoryId(),
+                        category.getCategoryName(),
+                        itemRepository.countByCategory_CategoryId(category.getCategoryId()) // 카테고리 별 아이템 수
+                ))
+                .collect(Collectors.toList());
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalCount", totalCategoryCount);
+        result.put("categories", categories);
+
+        return result;
+    }
+
+    @Override
+    public Map<String, Object> getItemsByCategory(Long categoryId) {
+        // 해당 카테고리의 아이템 목록
+        List<PuppyItem> items = itemRepository.findAllByCategory_CategoryId(categoryId);
+
+        List<ItemResponseDto> itemResponseList = items.stream()
+                .map(item -> new ItemResponseDto(
+                        item.getItemId(),
+                        item.getItemName(),
+                        item.getPrice()
+                ))
+                .collect(Collectors.toList());
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("totalCount", itemResponseList.size());  // 해당 카테고리의 아이템 수
+        result.put("items", itemResponseList);
+
+        return result;
+    }
+
+    @Override
+    public Map<String, Object> purchaseItem(Long categoryId, Long itemId, User user) {
+        // 강아지 조회
+        Puppy puppy = puppyRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 아이템 조회
+        PuppyItem item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이템이 존재하지 않습니다."));
+
+        // 카테고리 검증
+        if (!item.getCategory().getCategoryId().equals(categoryId)) {
+            throw new IllegalArgumentException("아이템이 해당 카테고리에 속하지 않습니다.");
+        }
+
+        // 이미 구매된 아이템인지 확인
+        boolean alreadyPurchased = puppyCustomizationRepository.existsByPuppyAndPuppyItem(puppy, item);
+        if (alreadyPurchased) {
+            throw new IllegalArgumentException("이미 구매한 아이템입니다.");
+        }
+
+        // 포인트 검증
+        if (user.getPoints() < item.getPrice()) {
+            throw new IllegalArgumentException("잔여 포인트가 부족합니다.");
+        }
+
+        // 포인트 차감 및 아이템 구매 처리
+        user.setPoints(user.getPoints() - item.getPrice());
+        PuppyCustomization customization = new PuppyCustomization();
+        customization.setPuppy(puppy);
+        customization.setPuppyItem(item);
+        customization.setIsEquipped(false); // 기본값은 장착되지 않은 상태
+        puppyCustomizationRepository.save(customization);
+
+        // 저장
+        userRepository.save(user);
+
+        // 응답 데이터 구성
+        Map<String, Object> response = new HashMap<>();
+        response.put("currentPoint", user.getPoints());
+        response.put("itemId", item.getItemId());
+
+        return response;
+    }
+
+    @Override
+    public Map<String, Object> equipItem(Long categoryId, Long itemId, User user) {
+        // 유저의 강아지 찾기
+        Puppy puppy = puppyRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 아이템 찾기
+        PuppyItem item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템이 존재하지 않습니다."));
+
+        // 카테고리 검증
+        if (!item.getCategory().getCategoryId().equals(categoryId)) {
+            throw new IllegalArgumentException("아이템이 해당 카테고리에 속하지 않습니다.");
+        }
+
+        // 아이템 구매 여부 확인
+        PuppyCustomization customization = puppyCustomizationRepository.findByPuppyAndPuppyItem(puppy, item)
+                .orElseThrow(() -> new IllegalArgumentException("강아지에게 해당 아이템이 없습니다."));
+
+        // 이미 착용 중인 아이템인지 확인
+        if (customization.getIsEquipped()) {
+            throw new IllegalArgumentException("이미 착용한 아이템입니다.");
+        }
+
+        // 아이템 착용 처리
+        customization.setIsEquipped(true);
+        puppyCustomizationRepository.save(customization);
+
+        // 강아지 이미지 갱신 (추후에 강아지의 이미지 URL을 업데이트하는 로직을 추가)
+        String updatedImageUrl = "";
+
+        // 응답 데이터 구성
+        Map<String, Object> response = new HashMap<>();
+        response.put("updatedPuppyImageUrl", updatedImageUrl);
+        response.put("equippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
+
+        return response;
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -1,0 +1,68 @@
+package umc.puppymode.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import umc.puppymode.domain.User;
+import umc.puppymode.service.PuppyService.PuppyItemService;
+import umc.puppymode.web.dto.ItemCategoryResponseDto;
+import umc.puppymode.web.dto.ItemResponseDto;
+import umc.puppymode.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/puppies")
+@RequiredArgsConstructor
+public class PuppyItemController {
+
+    private final PuppyItemService puppyItemService;
+
+    @Operation(summary = "카테고리 목록 조회 API", description = "꾸미기 아이템의 카테고리 목록을 조회하는 API")
+    @GetMapping("/categories")
+    public ApiResponse<Map<String, Object>> getAllCategories() {
+        Map<String, Object> categories = puppyItemService.getAllCategories();
+        return new ApiResponse<>(
+                true,
+                "SUCCESS_GET_PUPPY_CATEGORIES",
+                "카테고리 목록 조회 성공",
+                categories // Map 형태로 반환
+        );
+    }
+
+    @Operation(summary = "카테고리 별 아이템 목록 조회 API", description = "요청받은 카테고리에 해당하는 아이템 목록을 조회하는 API")
+    @GetMapping("/{categoryId}/items")
+    public ApiResponse<Map<String, Object>> getItemsByCategory(@PathVariable Long categoryId) {
+        return new ApiResponse<>(
+                true,
+                "SUCCESS_GET_PUPPY_CATEGORY_ITEMS",
+                "카테고리 별 아이템 목록 조회 성공",
+                puppyItemService.getItemsByCategory(categoryId) // Map 형태로 반환
+        );
+    }
+
+    @Operation(summary = "아이템 구매 API", description = "아이템을 구매하고 잔여 포인트와 아이템 ID를 반환하는 API")
+    @PostMapping("/{categoryId}/items/{itemId}")
+    public ResponseEntity<ApiResponse<Map<String, Object>>> purchaseItem(
+            @PathVariable Long categoryId,
+            @PathVariable Long itemId,
+            @AuthenticationPrincipal User user) {
+        Map<String, Object> result = puppyItemService.purchaseItem(categoryId, itemId, user);
+        // 유저 아이디 관련 추가 수정 필요
+        return ResponseEntity.ok(
+                new ApiResponse<>(true, "SUCCESS_POST_PUPPY_ITEM", "아이템 구매 성공", result)
+        );
+    }
+
+    @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API")
+    @PostMapping("/{categoryId}/items/{itemId}/equip")
+    public ApiResponse<Map<String, Object>> equipItem(@PathVariable Long categoryId,
+                                                      @PathVariable Long itemId,
+                                                      @AuthenticationPrincipal User user) {
+        Map<String, Object> result = puppyItemService.equipItem(categoryId, itemId, user);
+        return new ApiResponse<>(true, "SUCCESS_EQUIP_PUPPY_ITEM", "아이템 착용 성공", result);
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/dto/EquippedItemInfoDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/EquippedItemInfoDTO.java
@@ -1,0 +1,11 @@
+package umc.puppymode.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EquippedItemInfoDTO {
+    private Long itemId;
+    private String itemName;
+}

--- a/src/main/java/umc/puppymode/web/dto/ItemCategoryResponseDto.java
+++ b/src/main/java/umc/puppymode/web/dto/ItemCategoryResponseDto.java
@@ -1,0 +1,15 @@
+package umc.puppymode.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ItemCategoryResponseDto {
+    private Long categoryId; // 카테고리 ID
+    private String name; // 카테고리 이름
+    private Long itemCount; // 아이템 수
+}
+

--- a/src/main/java/umc/puppymode/web/dto/ItemResponseDto.java
+++ b/src/main/java/umc/puppymode/web/dto/ItemResponseDto.java
@@ -1,0 +1,15 @@
+package umc.puppymode.web.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ItemResponseDto {
+    private Long itemId; // 아이템 ID
+    private String name; // 아이템 이름
+    private Integer price; // 아이템 가격
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
강아지 꾸미기 관련 API 4개 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #16

## ⏳ 작업 내용
- 카테고리 별 목록 조회 API 
- 카테고리 조회 API 
- 아이템 구매 API 
- 아이템 착용 API 

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
아직 유저 관련, 이미지 관련은 구현하지 않았습니다.
