### PR TITLE
[FEAT] 음주 중 관련 기능 구현 #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+	//jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/umc/puppymode/apiPayload/ApiResponse.java
+++ b/src/main/java/umc/puppymode/apiPayload/ApiResponse.java
@@ -26,6 +26,14 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
     }
 
+    public static ApiResponse<Void> onSuccess(String code, String message) {
+        return new ApiResponse<>(true, code, message, null);
+    }
+
+    public static <T> ApiResponse<T> onSuccess(T result, String code, String message) {
+        return new ApiResponse<>(true, code, message, result);
+    }
+
     public static <T> ApiResponse<T> of(BaseCode code, T result){
         return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
     }

--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -32,9 +32,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 약속 시간 관련 예외 처리
     APPOINTMENT_TIME_MISMATCH(HttpStatus.BAD_REQUEST, "APPOINTMENT400", "약속 시간이 현재 시간과 다릅니다."),
+    APPOINTMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "APPOINTMENT404", "해당 ID의 약속을 찾을 수 없습니다."),
 
     // 요청 데이터가 유효하지 않은 경우
     INVALID_REQUEST_DATA(HttpStatus.BAD_REQUEST, "COMMON4001", "잘못된 요청 데이터입니다."),
+
 
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");

--- a/src/main/java/umc/puppymode/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/SuccessStatus.java
@@ -15,7 +15,9 @@ public enum SuccessStatus implements BaseCode {
     //술 약속
     APPOINTMENT_DELETE_SUCCESS(HttpStatus.OK, "SUCCESS_DELETE_APPOINTMENT", "술 약속 삭제 성공"),
     APPOINTMENT_GET_SUCCESS(HttpStatus.OK, "SUCCESS_GET_APPOINTMENT", "술 약속 조회 성공"),
-    APPOINTMENT_POST_SUCCESS(HttpStatus.OK, "SUCCESS_POST_APPOINTMENT", "술 약속 설정 성공");
+    APPOINTMENT_POST_SUCCESS(HttpStatus.OK, "SUCCESS_POST_APPOINTMENT", "술 약속 설정 성공"),
+    APPOINTMENT_STATUS_GET_SUCCESS(HttpStatus.OK, "SUCCESS_GET_APPOINTMENT_STATUS", "술 약속 활성화 상태 조회 성공"),
+    APPOINTMENT_RESCHEDULED_PATCH_SUCCESS(HttpStatus.OK, "SUCCESS_PUT_APPOINTMENT_RESCHEDULED", "술 약속 미루기 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/puppymode/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/SuccessStatus.java
@@ -10,7 +10,13 @@ import umc.puppymode.apiPayload.code.ReasonDTO;
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
 
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+
+    //술 약속
+    APPOINTMENT_DELETE_SUCCESS(HttpStatus.OK, "SUCCESS_DELETE_APPOINTMENT", "술 약속 삭제 성공"),
+    APPOINTMENT_GET_SUCCESS(HttpStatus.OK, "SUCCESS_GET_APPOINTMENT", "술 약속 조회 성공"),
+    APPOINTMENT_POST_SUCCESS(HttpStatus.OK, "SUCCESS_POST_APPOINTMENT", "술 약속 설정 성공");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
+++ b/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
@@ -15,8 +15,6 @@ public class DrinkingAppointmentConverter {
         entity.setLatitude(dto.getLatitude());
         entity.setLongitude(dto.getLongitude());
         entity.setLocationName(dto.getLocationName());
-        entity.setTitle(dto.getTitle());
-        entity.setDetails(dto.getDetails());
         entity.setStatus(AppointmentStatus.SCHEDULED); // 기본값 설정
         return entity;
     }

--- a/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
+++ b/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
@@ -1,0 +1,43 @@
+package umc.puppymode.converter;
+
+import umc.puppymode.domain.DrinkingAppointment;
+import umc.puppymode.domain.enums.AppointmentStatus;
+import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+
+public class DrinkingAppointmentConverter {
+    // DTO → Entity 변환
+    public static DrinkingAppointment toEntity(DrinkingAppointmentRequestDTO.AppointmentDTO dto) {
+        DrinkingAppointment entity = new DrinkingAppointment();
+        entity.setDateTime(dto.getDateTime());
+        entity.setAddress(dto.getAddress());
+        entity.setLatitude(dto.getLatitude());
+        entity.setLongitude(dto.getLongitude());
+        entity.setLocationName(dto.getLocationName());
+        entity.setTitle(dto.getTitle());
+        entity.setDetails(dto.getDetails());
+        entity.setStatus(AppointmentStatus.SCHEDULED); // 기본값 설정
+        return entity;
+    }
+
+    // Entity → DTO 변환, 상세 정보 위한 DTO -> 추후 약속 관련 상세 정보 포함 가능
+    public static DrinkingAppointmentResponseDTO.AppointmentResultDTO toDTO(DrinkingAppointment entity) {
+        return DrinkingAppointmentResponseDTO.AppointmentResultDTO.builder()
+                .appointmentId(entity.getAppointmentId())
+                .dateTime(entity.getDateTime())
+                .address(entity.getAddress())
+                .status(entity.getStatus().toString())
+                .build();
+    }
+
+    // 간단한 정보 조회 위한 DTO
+    public static DrinkingAppointmentResponseDTO.AppointmentSimpleDTO toSimpleDTO(DrinkingAppointment entity) {
+        return DrinkingAppointmentResponseDTO.AppointmentSimpleDTO.builder()
+                .appointmentId(entity.getAppointmentId())
+                .dateTime(entity.getDateTime())
+                .address(entity.getAddress())
+                .status(entity.getStatus().name().toLowerCase()) //일단 API 명세에는 소문자로 되어있어서 소문자 처리.
+                .build();
+    }
+}

--- a/src/main/java/umc/puppymode/domain/DrinkingAppointment.java
+++ b/src/main/java/umc/puppymode/domain/DrinkingAppointment.java
@@ -1,0 +1,50 @@
+package umc.puppymode.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import umc.puppymode.domain.common.BaseEntity;
+import umc.puppymode.domain.enums.AppointmentStatus;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class DrinkingAppointment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long appointmentId; // 술 약속 ID (PK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 술 약속 생성한 사용자 (FK)
+
+    @Column(nullable = false, length = 255)
+    private String title; // 술 약속 제목
+
+    @Column(nullable = false)
+    private LocalDateTime dateTime; // 술 약속 일시
+
+    @Column(nullable = false, length = 255)
+    private String locationName; // 장소 이름
+
+    @Column(nullable = false)
+    private Double latitude; // 장소 위도
+
+    @Column(nullable = false)
+    private Double longitude; // 장소 경도
+
+    @Column(nullable = false, length = 500)
+    private String address; // 장소 주소
+
+    @Column(columnDefinition = "TEXT")
+    private String details; // 추가 설명
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AppointmentStatus status; // 상태 필드
+
+}

--- a/src/main/java/umc/puppymode/domain/DrinkingAppointment.java
+++ b/src/main/java/umc/puppymode/domain/DrinkingAppointment.java
@@ -22,9 +22,6 @@ public class DrinkingAppointment extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user; // 술 약속 생성한 사용자 (FK)
 
-    @Column(nullable = false, length = 255)
-    private String title; // 술 약속 제목
-
     @Column(nullable = false)
     private LocalDateTime dateTime; // 술 약속 일시
 
@@ -39,9 +36,6 @@ public class DrinkingAppointment extends BaseEntity {
 
     @Column(nullable = false, length = 500)
     private String address; // 장소 주소
-
-    @Column(columnDefinition = "TEXT")
-    private String details; // 추가 설명
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/umc/puppymode/domain/enums/AppointmentStatus.java
+++ b/src/main/java/umc/puppymode/domain/enums/AppointmentStatus.java
@@ -1,0 +1,7 @@
+package umc.puppymode.domain.enums;
+
+public enum AppointmentStatus {
+    SCHEDULED,  // 예정된 약속
+    COMPLETED,  // 완료된 약속
+    CANCELED    // 취소된 약속
+}

--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -1,0 +1,13 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.puppymode.domain.DrinkingAppointment;
+import umc.puppymode.domain.enums.AppointmentStatus;
+
+@Repository
+public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingAppointment, Long> {
+    Page<DrinkingAppointment> findByStatus(AppointmentStatus status, Pageable pageable);
+}

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
@@ -1,0 +1,9 @@
+package umc.puppymode.service.DrinkingAppointmentService;
+
+import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+public interface DrinkingAppointmentCommendService {
+    DrinkingAppointmentResponseDTO.AppointmentResultDTO createDrinkingAppointment(DrinkingAppointmentRequestDTO.AppointmentDTO request);
+    void deleteDrinkingAppointment(Long appointmentId);
+}

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
@@ -6,4 +6,5 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 public interface DrinkingAppointmentCommendService {
     DrinkingAppointmentResponseDTO.AppointmentResultDTO createDrinkingAppointment(DrinkingAppointmentRequestDTO.AppointmentDTO request);
     void deleteDrinkingAppointment(Long appointmentId);
+    void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
@@ -1,0 +1,47 @@
+package umc.puppymode.service.DrinkingAppointmentService;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.puppymode.converter.DrinkingAppointmentConverter;
+import umc.puppymode.domain.DrinkingAppointment;
+import umc.puppymode.domain.User;
+import umc.puppymode.repository.DrinkingAppointmentRepository;
+import umc.puppymode.repository.UserRepository;
+import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+@Service
+@RequiredArgsConstructor
+public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmentCommendService {
+
+    private final DrinkingAppointmentRepository repository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public DrinkingAppointmentResponseDTO.AppointmentResultDTO createDrinkingAppointment(
+            DrinkingAppointmentRequestDTO.AppointmentDTO request) {
+
+        // User 엔티티 조회
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
+        // DTO → Entity 변환
+        DrinkingAppointment entity = DrinkingAppointmentConverter.toEntity(request);
+        // User 설정
+        entity.setUser(user);
+        // 데이터 저장
+        DrinkingAppointment savedEntity = repository.save(entity);
+        // Entity → DTO 변환
+        return DrinkingAppointmentConverter.toDTO(savedEntity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteDrinkingAppointment(Long appointmentId) {
+        DrinkingAppointment appointment = repository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        repository.delete(appointment);
+    }
+}

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
@@ -10,6 +10,7 @@ import umc.puppymode.repository.DrinkingAppointmentRepository;
 import umc.puppymode.repository.UserRepository;
 import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +26,7 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
 
         // User 엔티티 조회
         User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
         // DTO → Entity 변환
         DrinkingAppointment entity = DrinkingAppointmentConverter.toEntity(request);
         // User 설정
@@ -43,5 +44,21 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
 
         repository.delete(appointment);
+    }
+
+    @Override
+    @Transactional
+    public void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request) {
+
+        //약속 조회
+        DrinkingAppointment appointment = repository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 시간 유효성 검증
+        if (request.getDateTime().isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("현재 시간 이전으로 설정할 수 없습니다.");
+        }
+
+        appointment.setDateTime(request.getDateTime());
     }
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
@@ -1,0 +1,9 @@
+package umc.puppymode.service.DrinkingAppointmentService;
+
+import umc.puppymode.domain.enums.AppointmentStatus;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+public interface DrinkingAppointmentQueryService {
+    DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId);
+    DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size);
+}

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
@@ -1,9 +1,11 @@
 package umc.puppymode.service.DrinkingAppointmentService;
 
+import umc.puppymode.domain.DrinkingAppointment;
 import umc.puppymode.domain.enums.AppointmentStatus;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
 public interface DrinkingAppointmentQueryService {
     DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId);
     DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size);
+    boolean isAppointmentActive(Long appointmentId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
@@ -1,0 +1,54 @@
+package umc.puppymode.service.DrinkingAppointmentService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import umc.puppymode.converter.DrinkingAppointmentConverter;
+import umc.puppymode.domain.DrinkingAppointment;
+import umc.puppymode.domain.enums.AppointmentStatus;
+import umc.puppymode.repository.DrinkingAppointmentRepository;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DrinkingAppointmentQueryServiceImpl implements DrinkingAppointmentQueryService {
+
+    private final DrinkingAppointmentRepository drinkingAppointmentRepository;
+
+    @Override
+    public DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId) {
+        // 약속 조회
+        DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 엔티티 → DTO 변환
+        return DrinkingAppointmentConverter.toDTO(appointment);
+    }
+
+    @Override
+    public DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<DrinkingAppointment> appointments;
+
+        // 상태별 필터링
+        if (status != null) {
+            appointments = drinkingAppointmentRepository.findByStatus(status, pageable);
+        } else {
+            appointments = drinkingAppointmentRepository.findAll(pageable);
+        }
+
+        // DTO 변환
+        List<DrinkingAppointmentResponseDTO.AppointmentSimpleDTO> appointmentDTOs = appointments.stream()
+                .map(DrinkingAppointmentConverter::toSimpleDTO)
+                .toList();
+
+        return new DrinkingAppointmentResponseDTO.AppointmentListResultDTO(
+                appointments.getTotalElements(),
+                appointmentDTOs
+        );
+    }
+}

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
@@ -51,4 +51,14 @@ public class DrinkingAppointmentQueryServiceImpl implements DrinkingAppointmentQ
                 appointmentDTOs
         );
     }
+
+    @Override
+    public boolean isAppointmentActive(Long appointmentId) {
+
+        DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 약속을 찾을 수 없습니다."));
+
+        // isActive 판별
+        return appointment.getStatus() == AppointmentStatus.SCHEDULED;
+    }
 }

--- a/src/main/java/umc/puppymode/service/LocationService/LocationService.java
+++ b/src/main/java/umc/puppymode/service/LocationService/LocationService.java
@@ -1,0 +1,5 @@
+package umc.puppymode.service.LocationService;
+
+public interface LocationService {
+    // 술 약속 설정 위치와 사용자 현재 위치 간 거리계산 (필요 시)
+}

--- a/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
@@ -1,0 +1,5 @@
+package umc.puppymode.service.LocationService;
+
+public class LocationServiceImpl implements LocationService {
+
+}

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -1,15 +1,20 @@
 package umc.puppymode.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.apiPayload.code.status.SuccessStatus;
+import umc.puppymode.domain.DrinkingAppointment;
 import umc.puppymode.domain.enums.AppointmentStatus;
+import umc.puppymode.repository.DrinkingAppointmentRepository;
 import umc.puppymode.service.DrinkingAppointmentService.DrinkingAppointmentCommendService;
 import umc.puppymode.service.DrinkingAppointmentService.DrinkingAppointmentQueryService;
 import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,8 +22,10 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 public class DrinkingAppointmentController {
     private final DrinkingAppointmentCommendService drinkingAppointmentCommendService;
     private final DrinkingAppointmentQueryService drinkingAppointmentQueryService;
+    private final DrinkingAppointmentRepository drinkingAppointmentRepository;
 
     @PostMapping
+    @Operation(summary = "술 약속 생성 API", description = "술 약속 생성 API입니다 :)")
     public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentResultDTO> createAppointment(
             @Valid @RequestBody DrinkingAppointmentRequestDTO.AppointmentDTO request) {
 
@@ -31,6 +38,7 @@ public class DrinkingAppointmentController {
     }
 
     @GetMapping
+    @Operation(summary = "술 약속 전체 조회 API", description = "술 약속 리스트를 전체 조회하는 API입니다. page는 0부터 시작합니다. :)")
     public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentListResultDTO> getAllAppointments(
             @RequestParam(value = "status", required = false) AppointmentStatus status,
             @RequestParam(value = "page", defaultValue = "0") int page,
@@ -45,6 +53,7 @@ public class DrinkingAppointmentController {
 
 
     @GetMapping("/{appointmentId}")
+    @Operation(summary = "술 약속 단일 조회 API", description = "술 약속 ID로 필터링하여 술 약속을 단일 조회하는 API입니다 :)")
     public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentResultDTO> getAppointmentById(
             @PathVariable Long appointmentId) {
 
@@ -55,10 +64,40 @@ public class DrinkingAppointmentController {
         return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_GET_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_GET_SUCCESS.getMessage());
     }
 
+    @GetMapping("/{appointmentId}/status")
+    @Operation(summary = "술 약속 활성화 상태 조회 API", description = "술 약속 활성화 상태를 조회하며, 술 약속이 'SCHEDULED' 상태일 때 true로 반환합니다.:)")
+    public ApiResponse<?> getAppointmentStatus(@PathVariable Long appointmentId) {
+
+        boolean isActive = drinkingAppointmentQueryService.isAppointmentActive(appointmentId);
+        DrinkingAppointmentResponseDTO.AppointmentStatusResultDTO response = new DrinkingAppointmentResponseDTO.AppointmentStatusResultDTO(appointmentId, isActive);
+        return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_STATUS_GET_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_STATUS_GET_SUCCESS.getMessage());
+    }
+
     @DeleteMapping("/{appointmentId}")
+    @Operation(summary = "술 약속 삭제 API", description = "술 약속을 삭제하는 API입니다 :)")
     public ApiResponse<Void> deleteAppointment(@PathVariable Long appointmentId) {
+
         drinkingAppointmentCommendService.deleteDrinkingAppointment(appointmentId);
         return ApiResponse.onSuccess(SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getMessage());
+    }
+
+    @PatchMapping("/{appointmentId}/reschedule")
+    @Operation(summary = "술 약속 미루기 API", description = "술 약속 시간 재설정 후 데이터베이스에 patch합니다.")
+    public ApiResponse<?> rescheduleAppointment(
+            @PathVariable Long appointmentId,
+            @Valid @RequestBody DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request) {
+
+        //시간 업데이트
+        drinkingAppointmentCommendService.rescheduleDrinkingAppointment(appointmentId, request);
+
+        // 업데이트된 상태를 엔티티에서 가져옴
+        DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalStateException("업데이트 후 약속을 찾을 수 없습니다."));
+
+        DrinkingAppointmentResponseDTO.RescheduleResultDTO response = new DrinkingAppointmentResponseDTO.RescheduleResultDTO(appointmentId, appointment.getDateTime());
+
+        return ApiResponse.onSuccess(SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getMessage());
+
     }
 
 }

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -1,0 +1,64 @@
+package umc.puppymode.web.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.apiPayload.code.status.SuccessStatus;
+import umc.puppymode.domain.enums.AppointmentStatus;
+import umc.puppymode.service.DrinkingAppointmentService.DrinkingAppointmentCommendService;
+import umc.puppymode.service.DrinkingAppointmentService.DrinkingAppointmentQueryService;
+import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
+import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/appointments")
+public class DrinkingAppointmentController {
+    private final DrinkingAppointmentCommendService drinkingAppointmentCommendService;
+    private final DrinkingAppointmentQueryService drinkingAppointmentQueryService;
+
+    @PostMapping
+    public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentResultDTO> createAppointment(
+            @Valid @RequestBody DrinkingAppointmentRequestDTO.AppointmentDTO request) {
+
+        // 서비스 호출
+        DrinkingAppointmentResponseDTO.AppointmentResultDTO response =
+                drinkingAppointmentCommendService.createDrinkingAppointment(request);
+
+        // 응답 반환
+        return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_POST_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_POST_SUCCESS.getMessage());
+    }
+
+    @GetMapping
+    public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentListResultDTO> getAllAppointments(
+            @RequestParam(value = "status", required = false) AppointmentStatus status,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size) {
+
+        // 서비스 호출
+        DrinkingAppointmentResponseDTO.AppointmentListResultDTO response =
+                drinkingAppointmentQueryService.getAllDrinkingAppointments(status, page, size);
+
+        return ApiResponse.onSuccess(response, "SUCCESS_GET_ALL_APPOINTMENTS", "술 약속 리스트 조회 성공");
+    }
+
+
+    @GetMapping("/{appointmentId}")
+    public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentResultDTO> getAppointmentById(
+            @PathVariable Long appointmentId) {
+
+        // 서비스 호출
+        DrinkingAppointmentResponseDTO.AppointmentResultDTO response =
+                drinkingAppointmentQueryService.getDrinkingAppointmentById(appointmentId);
+
+        return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_GET_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_GET_SUCCESS.getMessage());
+    }
+
+    @DeleteMapping("/{appointmentId}")
+    public ApiResponse<Void> deleteAppointment(@PathVariable Long appointmentId) {
+        drinkingAppointmentCommendService.deleteDrinkingAppointment(appointmentId);
+        return ApiResponse.onSuccess(SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/controller/LocationController.java
+++ b/src/main/java/umc/puppymode/web/controller/LocationController.java
@@ -1,0 +1,29 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.web.dto.LocationRequestDTO;
+import umc.puppymode.web.dto.LocationResponseDTO;
+
+@RestController
+@RequestMapping("/locations")
+public class LocationController {
+
+    @PostMapping
+    @Operation(summary = "사용자 현재 위치 조회 API", description = "사용자의 현재 위치의 위도와 경도를 반환합니다.")
+    public ApiResponse<LocationResponseDTO> getCurrentLocation(@RequestBody @Valid LocationRequestDTO request) {
+
+        // 데이터 반환
+        LocationResponseDTO response = new LocationResponseDTO(
+                request.getLatitude(),
+                request.getLongitude()
+        );
+
+        return ApiResponse.onSuccess(response, "SUCCESS_GET_CURRENT_LOCATION", "사용자 현재 위치 조회 성공");
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
@@ -1,0 +1,46 @@
+package umc.puppymode.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+
+public class DrinkingAppointmentRequestDTO {
+
+    @Getter
+    public static class AppointmentDTO {
+        @NotNull(message = "날짜 및 시간은 필수입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime dateTime;
+
+        @NotNull(message = "위도 값은 필수입니다.")
+        @Min(value = -90, message = "위도 값은 -90 이상이어야 합니다.")
+        @Max(value = 90, message = "위도 값은 90 이하여야 합니다.")
+        private Double latitude;
+
+        @NotNull(message = "경도 값은 필수입니다.")
+        @Min(value = -180, message = "경도 값은 -180 이상이어야 합니다.")
+        @Max(value = 180, message = "경도 값은 180 이하여야 합니다.")
+        private Double longitude;
+
+        @NotBlank(message = "주소는 필수입니다.")
+        private String address;
+
+        @NotBlank(message = "장소 이름은 필수입니다.")
+        @Size(max = 255, message = "장소 이름은 255자 이하여야 합니다.")
+        private String locationName;
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
+        private String title;
+
+        @NotNull(message = "유저 ID는 필수 입력 사항입니다.")
+        private Long userId;
+
+        private String details; // 추가 설명 (선택적 입력)
+    }
+}
+
+

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
@@ -32,14 +32,8 @@ public class DrinkingAppointmentRequestDTO {
         @Size(max = 255, message = "장소 이름은 255자 이하여야 합니다.")
         private String locationName;
 
-        @NotBlank(message = "제목은 필수입니다.")
-        @Size(max = 255, message = "제목은 255자 이하여야 합니다.")
-        private String title;
-
         @NotNull(message = "유저 ID는 필수 입력 사항입니다.")
         private Long userId;
-
-        private String details; // 추가 설명 (선택적 입력)
     }
 }
 

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
@@ -11,6 +11,7 @@ public class DrinkingAppointmentRequestDTO {
 
     @Getter
     public static class AppointmentDTO {
+        //날짜가 오늘로 고정인지, 아니면 변동 가능한 지에 따라 추후 수정가능성 있습니다.
         @NotNull(message = "날짜 및 시간은 필수입니다.")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         private LocalDateTime dateTime;
@@ -32,8 +33,17 @@ public class DrinkingAppointmentRequestDTO {
         @Size(max = 255, message = "장소 이름은 255자 이하여야 합니다.")
         private String locationName;
 
+        // userId는 시큐리티 구현 후 토큰 발급이 되면 추후 수정.
         @NotNull(message = "유저 ID는 필수 입력 사항입니다.")
         private Long userId;
+    }
+
+    @Getter
+    public static class RescheduleAppointmentRequestDTO {
+        // 술 약속 설정과 마찬가지로 오늘 고정인지, 날짜 자체 변동이 가능한지에 따라 수정가능성 있습니다.
+        @NotNull(message = "날짜 및 시간은 필수입니다.")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime dateTime;
     }
 }
 

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.puppymode.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -32,5 +33,25 @@ public class DrinkingAppointmentResponseDTO {
     public static class AppointmentListResultDTO {
         private long totalCount;
         private List<AppointmentSimpleDTO> appointments;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class AppointmentStatusResultDTO {
+        private Long appointmentId;
+
+        @Getter(AccessLevel.NONE)
+        private boolean isActive;
+
+        public boolean getIsActive() {
+            return isActive;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class RescheduleResultDTO {
+        private Long appointmentId;
+        private LocalDateTime rescheduledTime;
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
@@ -1,0 +1,36 @@
+package umc.puppymode.web.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DrinkingAppointmentResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppointmentResultDTO{
+        private Long appointmentId; // 약속 ID
+        private LocalDateTime dateTime; // 약속 날짜 및 시간
+        private String address; // 약속 장소
+        private String status;
+    }
+
+    @Getter
+    @Builder
+    public static class AppointmentSimpleDTO {
+        private Long appointmentId;
+        private LocalDateTime dateTime;
+        private String address;
+        private String status;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class AppointmentListResultDTO {
+        private long totalCount;
+        private List<AppointmentSimpleDTO> appointments;
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/LocationRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/LocationRequestDTO.java
@@ -1,0 +1,15 @@
+package umc.puppymode.web.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LocationRequestDTO {
+    @NotNull(message = "위도 값은 필수입니다.")
+    private Double latitude;
+
+    @NotNull(message = "경도 값은 필수입니다.")
+    private Double longitude;
+}

--- a/src/main/java/umc/puppymode/web/dto/LocationResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/LocationResponseDTO.java
@@ -1,0 +1,11 @@
+package umc.puppymode.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LocationResponseDTO {
+    private Double latitude;
+    private Double longitude;
+}


### PR DESCRIPTION
# 🚀 개요
음주 중 관련 기능을 구현합니다.

## 📌 관련 이슈번호
- Closes #19

## ⏳ 작업 내용
- 사용자 현재 위치 조회하기 API
- 술 약속 활성화 상태 조회하기 API
- 술 약속 미루기 API

### 📝 논의사항
"사용자의 현재 위치 조회 API”의 경우 일단 추후 프론트에서 위도와 경도를 보내주시면, 해당 값을 반환하도록 했습니다.

제가 이해하기로는 술약속 미루기가 있는 이유가 술 약속 시간에 유저가 해당 장소에 없거나, 시간 상 늦을 것 같으면 미루는 것 같은데, 해당 장소+시간에 유저가 도착하면 음주상태가 자동으로 음주 중으로 바뀌는 것인지, 본인이 설정하는 것인지 일단 PM님 답변 대기 중입니다. 

전자라면, 기존에 설정한 장소와 현재 위치의 거리계산 로직이 필요할 것 같고, 이 부은 추후 서비스에서 추가하도록 하겠습니다,,

단순 지도에 현재 위치가 표기되는 것이면, 디비에 저장을 안해도 될 것 같은데, 추후 기능이 있을 것 같아 일단은 명세서에 따라 조회된 사용자의 현재 위치만 받아오는 API로 두었습니다.

음주 상태 관련 API 2가지 (음주 상태 조회, 음주 상태 종료 API)는 제가 임의로 하기에는 담당해주시는 분과 충돌이 날 것 같아서, 추후 음주 기록 관련 주요 API가 완성되면 추가하기 위해 아직 구현을 하지 않은 상황입니다..

혹시.. 궁금한 점이 있는데, 음주 상태(drink_staus) 관련해서 이걸 user보다는 drink_history에 넣는 것이 나을 것 같아서 ,,혹시 괜찮은지 확인 한번만 부탁드리겠습니다ㅠ