### PR TITLE
[FEAT] 음주 기록 관련 API 구현 #14

### DIFF
--- a/src/main/java/umc/puppymode/domain/DrinkCategory.java
+++ b/src/main/java/umc/puppymode/domain/DrinkCategory.java
@@ -1,0 +1,21 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.List;
+import umc.puppymode.domain.common.BaseEntity;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrinkCategory  extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categoryId;
+
+    private String categoryName;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<DrinkItem> items;
+}

--- a/src/main/java/umc/puppymode/domain/DrinkItem.java
+++ b/src/main/java/umc/puppymode/domain/DrinkItem.java
@@ -1,0 +1,28 @@
+package umc.puppymode.domain;
+
+import umc.puppymode.domain.common.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrinkItem  extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long itemId;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private DrinkCategory category;
+
+    private String itemName;
+
+    private Float alcoholPercentage;
+
+    private Integer volumeMl;
+
+    private String imageUrl;
+}

--- a/src/main/java/umc/puppymode/domain/HangoverItem.java
+++ b/src/main/java/umc/puppymode/domain/HangoverItem.java
@@ -1,0 +1,20 @@
+package umc.puppymode.domain;
+
+import umc.puppymode.domain.common.BaseEntity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HangoverItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long hangoverId;
+
+    private String hangoverName;
+
+    private String imageUrl;
+}

--- a/src/main/java/umc/puppymode/repository/DrinkCategoryRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkCategoryRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.DrinkCategory;
+
+public interface DrinkCategoryRepository extends JpaRepository<DrinkCategory, Long> {
+}

--- a/src/main/java/umc/puppymode/repository/HangoverRepository.java
+++ b/src/main/java/umc/puppymode/repository/HangoverRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.HangoverItem;
+
+public interface HangoverRepository extends JpaRepository<HangoverItem, Long> {
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandService.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandService.java
@@ -1,0 +1,4 @@
+package umc.puppymode.service.DrinkService;
+
+public interface DrinkCommandService {
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
@@ -1,0 +1,11 @@
+package umc.puppymode.service.DrinkService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DrinkCommandServiceImpl implements DrinkCommandService {
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
@@ -1,9 +1,10 @@
 package umc.puppymode.service.DrinkService;
 
-import umc.puppymode.web.dto.DrinkResponseDTO.HangoverResponseDTO;
+import umc.puppymode.web.dto.DrinkResponseDTO.*;
 
 import java.util.List;
 
 public interface DrinkQueryService {
    List<HangoverResponseDTO> getAllHangovers();
+   List<CategoryResponseDTO> getAllDrinkCategories();
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
@@ -1,0 +1,9 @@
+package umc.puppymode.service.DrinkService;
+
+import umc.puppymode.web.dto.DrinkResponseDTO.HangoverResponseDTO;
+
+import java.util.List;
+
+public interface DrinkQueryService {
+   List<HangoverResponseDTO> getAllHangovers();
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryService.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface DrinkQueryService {
    List<HangoverResponseDTO> getAllHangovers();
    List<CategoryResponseDTO> getAllDrinkCategories();
+   DrinkItemsByCategoryResponseDTO getAllDrinkItemsByCategory(Long categoryId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
@@ -3,8 +3,9 @@ package umc.puppymode.service.DrinkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.repository.DrinkCategoryRepository;
 import umc.puppymode.repository.HangoverRepository;
-import umc.puppymode.web.dto.DrinkResponseDTO.HangoverResponseDTO;
+import umc.puppymode.web.dto.DrinkResponseDTO.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 public class DrinkQueryServiceImpl implements DrinkQueryService {
 
     private final HangoverRepository hangoverRepository;
+    private final DrinkCategoryRepository drinkCategoryRepository;
 
     public List<HangoverResponseDTO> getAllHangovers() { {
             return hangoverRepository.findAll().stream()
@@ -25,5 +27,15 @@ public class DrinkQueryServiceImpl implements DrinkQueryService {
                             .build())
                     .collect(Collectors.toList());
         }
+    }
+
+    @Override
+    public List<CategoryResponseDTO> getAllDrinkCategories() {
+        return drinkCategoryRepository.findAll().stream()
+                .map(item -> CategoryResponseDTO.builder()
+                        .categoryId(item.getCategoryId())
+                        .categoryName(item.getCategoryName())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package umc.puppymode.service.DrinkService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.repository.HangoverRepository;
+import umc.puppymode.web.dto.DrinkResponseDTO.HangoverResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DrinkQueryServiceImpl implements DrinkQueryService {
+
+    private final HangoverRepository hangoverRepository;
+
+    public List<HangoverResponseDTO> getAllHangovers() { {
+            return hangoverRepository.findAll().stream()
+                    .map(item -> HangoverResponseDTO.builder()
+                            .hangoverId(item.getHangoverId())
+                            .hangoverName(item.getHangoverName())
+                            .imageUrl(item.getImageUrl())
+                            .build())
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
@@ -3,6 +3,7 @@ package umc.puppymode.service.DrinkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.domain.DrinkCategory;
 import umc.puppymode.repository.DrinkCategoryRepository;
 import umc.puppymode.repository.HangoverRepository;
 import umc.puppymode.web.dto.DrinkResponseDTO.*;
@@ -37,5 +38,30 @@ public class DrinkQueryServiceImpl implements DrinkQueryService {
                         .categoryName(item.getCategoryName())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public DrinkItemsByCategoryResponseDTO getAllDrinkItemsByCategory(Long categoryId) {
+        // 카테고리 조회
+        DrinkCategory category = drinkCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다: " + categoryId));
+
+        // DrinkItem 변환
+        List<DrinksResponseDTO> items = category.getItems().stream()
+                .map(item -> DrinksResponseDTO.builder()
+                        .itemId(item.getItemId())
+                        .itemName(item.getItemName())
+                        .alcoholPercentage(item.getAlcoholPercentage())
+                        .volumeMl(item.getVolumeMl())
+                        .imageUrl(item.getImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 카테고리 및 아이템 데이터를 포함한 응답 DTO 생성
+        return DrinkItemsByCategoryResponseDTO.builder()
+                .categoryId(category.getCategoryId())
+                .categoryName(category.getCategoryName())
+                .items(items)
+                .build();
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/DrinkController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkController.java
@@ -1,0 +1,28 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.DrinkService.DrinkQueryService;
+import umc.puppymode.web.dto.DrinkResponseDTO;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/")
+public class DrinkController {
+
+    private final DrinkQueryService drinkQueryService;
+
+    @GetMapping("hangover")
+    @Operation(summary = "숙취 목록 조회 API", description = "숙취 목록을 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<List<DrinkResponseDTO.HangoverResponseDTO>>> getHangovers() {
+        List<DrinkResponseDTO.HangoverResponseDTO> responseDTO = drinkQueryService.getAllHangovers();
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
+}

--- a/src/main/java/umc/puppymode/web/controller/DrinkController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkController.java
@@ -25,4 +25,11 @@ public class DrinkController {
         List<DrinkResponseDTO.HangoverResponseDTO> responseDTO = drinkQueryService.getAllHangovers();
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
+
+    @GetMapping("drinks/categories")
+    @Operation(summary = "술 카테고리 조회 API", description = "술 카테고리를 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<List<DrinkResponseDTO.CategoryResponseDTO>>> getDrinkCategories() {
+        List<DrinkResponseDTO.CategoryResponseDTO> responseDTO = drinkQueryService.getAllDrinkCategories();
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
 }

--- a/src/main/java/umc/puppymode/web/controller/DrinkController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkController.java
@@ -3,12 +3,10 @@ package umc.puppymode.web.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.service.DrinkService.DrinkQueryService;
-import umc.puppymode.web.dto.DrinkResponseDTO;
+import umc.puppymode.web.dto.DrinkResponseDTO.*;
 
 import java.util.List;
 
@@ -21,15 +19,22 @@ public class DrinkController {
 
     @GetMapping("hangover")
     @Operation(summary = "숙취 목록 조회 API", description = "숙취 목록을 조회하는 API입니다.")
-    public ResponseEntity<ApiResponse<List<DrinkResponseDTO.HangoverResponseDTO>>> getHangovers() {
-        List<DrinkResponseDTO.HangoverResponseDTO> responseDTO = drinkQueryService.getAllHangovers();
+    public ResponseEntity<ApiResponse<List<HangoverResponseDTO>>> getHangovers() {
+        List<HangoverResponseDTO> responseDTO = drinkQueryService.getAllHangovers();
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
 
     @GetMapping("drinks/categories")
     @Operation(summary = "술 카테고리 조회 API", description = "술 카테고리를 조회하는 API입니다.")
-    public ResponseEntity<ApiResponse<List<DrinkResponseDTO.CategoryResponseDTO>>> getDrinkCategories() {
-        List<DrinkResponseDTO.CategoryResponseDTO> responseDTO = drinkQueryService.getAllDrinkCategories();
+    public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getDrinkCategories() {
+        List<CategoryResponseDTO> responseDTO = drinkQueryService.getAllDrinkCategories();
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
+
+    @GetMapping("drinks/categories/{categoryId}")
+    @Operation(summary = "카테고리 별 술 목록 조회 API", description = "카테고리 별 술 목록을 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<DrinkItemsByCategoryResponseDTO>> getDrinksByCategory(@PathVariable Long categoryId) {
+        DrinkItemsByCategoryResponseDTO responseDTO = drinkQueryService.getAllDrinkItemsByCategory(categoryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkRequestDTO.java
@@ -1,0 +1,4 @@
+package umc.puppymode.web.dto;
+
+public class DrinkRequestDTO {
+}

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -10,9 +10,16 @@ public class DrinkResponseDTO {
     @AllArgsConstructor
     public static class HangoverResponseDTO {
         private Long hangoverId;
-
         private String hangoverName;
-
         private String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryResponseDTO {
+        private Long categoryId;
+        private String categoryName;
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -2,6 +2,8 @@ package umc.puppymode.web.dto;
 
 import lombok.*;
 
+import java.util.List;
+
 public class DrinkResponseDTO {
 
     @Builder
@@ -21,5 +23,27 @@ public class DrinkResponseDTO {
     public static class CategoryResponseDTO {
         private Long categoryId;
         private String categoryName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DrinksResponseDTO {
+        private Long itemId;
+        private String itemName;
+        private Float alcoholPercentage;
+        private Integer volumeMl;
+        private String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DrinkItemsByCategoryResponseDTO {
+        private Long categoryId;
+        private String categoryName;
+        private List<DrinksResponseDTO> items;
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -1,0 +1,18 @@
+package umc.puppymode.web.dto;
+
+import lombok.*;
+
+public class DrinkResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HangoverResponseDTO {
+        private Long hangoverId;
+
+        private String hangoverName;
+
+        private String imageUrl;
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
음주 기록 관련 API 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #14

## ⏳ 작업 내용
- 숙취 목록 조회하기 API
- 술 카테고리 조회하기 API
- 카테고리 별 술 목록 조회하기 API

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
