### PR TITLE
[Feat] AWS S3 이미지 파일 업로드 구현 #25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	// Firebase Admin
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
 
+	// AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 jar {

--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -48,7 +48,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 이미지 관련 예외 처리
     EMPTY_FILE_LIST(HttpStatus.BAD_REQUEST, "IMAGE4001", "요청 파일 목록이 비어있습니다."),
     INVALID_FILE_UPLOAD(HttpStatus.BAD_REQUEST, "IMAGE4002", "파일이 비어있거나 유효하지 않습니다."),
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500", "파일 업로드에 실패했습니다")
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE500", "파일 업로드에 실패했습니다"),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 이름의 이미지가 버킷에 존재하지 않습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE500", "이미지를 버킷에서 삭제하는데 실패했습니다.")
 
     ;
 

--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -43,7 +43,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 강아지 관련 예외 처리
     PUPPY_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY404", "해당 ID를 가진 강아지를 찾을 수 없습니다."),
-    UNAUTHORIZED_PUPPY_ACCESS(HttpStatus.UNAUTHORIZED, "PUPPY401", "강아지에 대한 접근 권한이 없습니다.")
+    UNAUTHORIZED_PUPPY_ACCESS(HttpStatus.UNAUTHORIZED, "PUPPY401", "강아지에 대한 접근 권한이 없습니다."),
+
+    // 이미지 관련 예외 처리
+    EMPTY_FILE_LIST(HttpStatus.BAD_REQUEST, "IMAGE4001", "요청 파일 목록이 비어있습니다."),
+    INVALID_FILE_UPLOAD(HttpStatus.BAD_REQUEST, "IMAGE4002", "파일이 비어있거나 유효하지 않습니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AWS500", "파일 업로드에 실패했습니다")
 
     ;
 

--- a/src/main/java/umc/puppymode/config/AwsS3Config.java
+++ b/src/main/java/umc/puppymode/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package umc.puppymode.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3Service.java
+++ b/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3Service.java
@@ -1,0 +1,13 @@
+package umc.puppymode.service.AwsS3Service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface AwsS3Service {
+
+    // S3 버킷에 이미지를 업로드
+    List<String> uploadImages(List<MultipartFile> multipartFiles);
+    // S3 버킷에서 이미지 삭제
+    void deleteImage(String imageUrl);
+}

--- a/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3ServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3ServiceImpl.java
@@ -1,6 +1,7 @@
 package umc.puppymode.service.AwsS3Service;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
@@ -65,7 +66,15 @@ public class AwsS3ServiceImpl implements AwsS3Service {
         String imageName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
 
         DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, imageName);
-        amazonS3.deleteObject(deleteObjectRequest);
+        try {
+            amazonS3.deleteObject(deleteObjectRequest);
+        } catch (AmazonS3Exception e) {
+            if (e.getStatusCode() == 404) {
+                throw new GeneralException(ErrorStatus.IMAGE_NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.FILE_DELETE_FAILED);
+        }
     }
 
     // UUID 사용하여 새로운 파일 이름 생성

--- a/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3ServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AwsS3Service/AwsS3ServiceImpl.java
@@ -1,0 +1,75 @@
+package umc.puppymode.service.AwsS3Service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.GeneralException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AwsS3ServiceImpl implements AwsS3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    @Override
+    // S3 버킷에 이미지를 업로드
+    public List<String> uploadImages(List<MultipartFile> multipartFiles) {
+
+        // S3 업로드 완료한 이미지들의 접근 가능한 url 담을 리스트
+        List<String> imageUrls = new ArrayList<>();
+
+        for (MultipartFile multipartFile : multipartFiles) {
+
+            if (multipartFile == null || multipartFile.isEmpty()) {
+                throw new GeneralException(ErrorStatus.INVALID_FILE_UPLOAD);
+            }
+            // 고유한 UUID 사용하여 새로운 파일 이름 생성 (동일 파일명일 경우 대비)
+            String s3FileName = createUniqueName(multipartFile.getOriginalFilename());
+
+            try {
+                ObjectMetadata objectMetadata = new ObjectMetadata();
+                objectMetadata.setContentType(multipartFile.getContentType());
+                objectMetadata.setContentLength(multipartFile.getSize());
+
+                amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, multipartFile.getInputStream(), objectMetadata));
+
+            } catch (IOException e) {
+                throw new GeneralException(ErrorStatus.FILE_UPLOAD_FAILED);
+            }
+            imageUrls.add("https://d1le4wcgenmery.cloudfront.net/" + s3FileName);
+        }
+        return imageUrls;
+    }
+
+    @Override
+    // S3 버킷에서 이미지 삭제
+    public void deleteImage(String imageUrl) {
+
+        // signed url을 포함한 전체 url에서 이미지 이름만 분리
+        String imageName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, imageName);
+        amazonS3.deleteObject(deleteObjectRequest);
+    }
+
+    // UUID 사용하여 새로운 파일 이름 생성
+    private String createUniqueName(String fileName) {
+        return UUID.randomUUID() + fileName;
+    }
+}

--- a/src/main/java/umc/puppymode/web/controller/AwsS3Controller.java
+++ b/src/main/java/umc/puppymode/web/controller/AwsS3Controller.java
@@ -1,0 +1,41 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.handler.TempHandler;
+import umc.puppymode.service.AwsS3Service.AwsS3Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class AwsS3Controller {
+
+    private final AwsS3Service awsS3Service;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "AWS S3 이미지 업로드 API", description = "S3 버킷에 이미지를 업로드합니다. 반환값은 접근 가능한 이미지의 url입니다.")
+    public ApiResponse<List<String>> uploadImage(@RequestPart(value = "uploadFiles", required = false) List<MultipartFile> multipartFiles) {
+
+        if (multipartFiles == null || multipartFiles.isEmpty()) {
+            throw new TempHandler(ErrorStatus.EMPTY_FILE_LIST);
+        }
+        // 유효한 파일이 있는 경우 uploadImages 실행
+        return ApiResponse.onSuccess(awsS3Service.uploadImages(multipartFiles));
+    }
+
+    @DeleteMapping
+    @Operation(summary = "AWS S3 이미지 삭제 API", description = "S3 버킷에서 이미지를 삭제합니다.")
+    public ApiResponse<String> deleteImageFromCapsule(@RequestParam String imageUrl) {
+
+        awsS3Service.deleteImage(imageUrl);
+        return ApiResponse.onSuccess("이미지가 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/umc/puppymode/web/controller/AwsS3Controller.java
+++ b/src/main/java/umc/puppymode/web/controller/AwsS3Controller.java
@@ -32,7 +32,7 @@ public class AwsS3Controller {
     }
 
     @DeleteMapping
-    @Operation(summary = "AWS S3 이미지 삭제 API", description = "S3 버킷에서 이미지를 삭제합니다.")
+    @Operation(summary = "AWS S3 이미지 삭제 API", description = "S3 버킷에서 이미지를 삭제합니다. 요청 파라미터에는 삭제하고자 하는 이미지의 접근 가능한 url 전체를 넣어주시면 됩니다.")
     public ApiResponse<String> deleteImageFromCapsule(@RequestParam String imageUrl) {
 
         awsS3Service.deleteImage(imageUrl);


### PR DESCRIPTION
# 🚀 개요
- 이미지를 다중선택하여 업로드 시, 업로드 된 파일의 URL들을 반환하는 API
- 이미지 url을 사용하여 업로드된 파일을 삭제하는 API

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #25 

## ⏳ 작업 내용
- 4219ac17eb5595fd8353f1cf56943dc7c1429bc5 : 이미지 업로드 및 삭제 api 구현
- c604b4d480022db84c6844414e7b0b653936ff3a : 이미지 삭제 시 올바르지 않은 파일 url에 대한 에러처리 추가

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
