### PR TITLE
Feat/#12 spring security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,10 @@ repositories {
 }
 
 dependencies {
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -48,6 +50,14 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 jar {

--- a/src/main/java/umc/puppymode/config/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/umc/puppymode/config/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,23 @@
+package umc.puppymode.config.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}
+

--- a/src/main/java/umc/puppymode/config/security/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/umc/puppymode/config/security/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package umc.puppymode.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/umc/puppymode/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/puppymode/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package umc.puppymode.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static umc.puppymode.config.security.JwtValidationType.VALID_JWT;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            final String token = getJwtFromRequest(request);
+            if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+                // authentication 객체 생성 -> principal에 유저정보를 담는다.
+                UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            try {
+                throw new Exception();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/umc/puppymode/config/security/JwtTokenProvider.java
+++ b/src/main/java/umc/puppymode/config/security/JwtTokenProvider.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -19,7 +18,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private static final String MEMBER_ID = "memberId";
+    private static final String USER_ID = "userId";
     private static final Long TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L;
 
     @Value("${jwt.secret}")
@@ -40,7 +39,7 @@ public class JwtTokenProvider {
 
         log.info("Principal: {}", authentication.getPrincipal());
 
-        claims.put(MEMBER_ID, authentication.getPrincipal());
+        claims.put(USER_ID, authentication.getPrincipal());
 
         log.info("Claims before signing: {}", claims); // JWT 생성 전 Claims 확인
         return Jwts.builder()
@@ -80,7 +79,7 @@ public class JwtTokenProvider {
 
     public Long getUserFromJwt(String token) {
         Claims claims = getBody(token);
-        return Long.valueOf(claims.get(MEMBER_ID).toString());
+        return Long.valueOf(claims.get(USER_ID).toString());
     }
 }
 

--- a/src/main/java/umc/puppymode/config/security/JwtTokenProvider.java
+++ b/src/main/java/umc/puppymode/config/security/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package umc.puppymode.config.security;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String MEMBER_ID = "memberId";
+    private static final Long TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L;
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    @PostConstruct
+    protected void init() {
+        //base64 라이브러리에서 encodeToString을 이용해서 byte[] 형식을 String 형식으로 변환
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Authentication authentication) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TOKEN_EXPIRATION_TIME));  // 만료 시간 설정
+
+        log.info("Principal: {}", authentication.getPrincipal());
+
+        claims.put(MEMBER_ID, authentication.getPrincipal());
+
+        log.info("Claims before signing: {}", claims); // JWT 생성 전 Claims 확인
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+    }
+
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(MEMBER_ID).toString());
+    }
+}
+

--- a/src/main/java/umc/puppymode/config/security/JwtValidationType.java
+++ b/src/main/java/umc/puppymode/config/security/JwtValidationType.java
@@ -1,0 +1,10 @@
+package umc.puppymode.config.security;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/umc/puppymode/config/security/SecurityConfig.java
+++ b/src/main/java/umc/puppymode/config/security/SecurityConfig.java
@@ -1,0 +1,53 @@
+package umc.puppymode.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain (HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/auth/kakao/login", "/auth/apple/login", "/auth/logout").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(csrf -> csrf.disable())
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .bearerTokenResolver(bearerTokenResolver())
+                )
+                .logout((logout) -> logout
+                        .logoutUrl("/auth/logout")
+                        .logoutSuccessHandler((request, response, authentication) -> {
+                            response.setStatus(200);
+                            response.getWriter().write("{\"message\": \"Logout successful\"}"); // TODO: 응답 형식에 맞게 수정
+                            response.getWriter().flush();
+                        })
+                        .permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public BearerTokenResolver bearerTokenResolver() {
+        DefaultBearerTokenResolver resolver = new DefaultBearerTokenResolver();
+        resolver.setAllowFormEncodedBodyParameter(true);
+        resolver.setAllowUriQueryParameter(true);
+        return resolver;
+    }
+}

--- a/src/main/java/umc/puppymode/config/security/SecurityConfig.java
+++ b/src/main/java/umc/puppymode/config/security/SecurityConfig.java
@@ -1,14 +1,15 @@
 package umc.puppymode.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
-import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import umc.puppymode.apiPayload.ApiResponse;
 
 @EnableWebSecurity
 @Configuration
@@ -22,14 +23,19 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .csrf(csrf -> csrf.disable())
-                .oauth2ResourceServer(oauth2 -> oauth2
-                        .bearerTokenResolver(bearerTokenResolver())
-                )
+//                .oauth2ResourceServer(oauth2 -> oauth2
+//                        .jwt()
+//                ) // TODO: jwt구현
                 .logout((logout) -> logout
                         .logoutUrl("/auth/logout")
                         .logoutSuccessHandler((request, response, authentication) -> {
-                            response.setStatus(200);
-                            response.getWriter().write("{\"message\": \"Logout successful\"}"); // TODO: 응답 형식에 맞게 수정
+                            ApiResponse<String> logoutResponse = ApiResponse.onSuccess("로그아웃 성공");
+
+                            response.setContentType("application/json");
+                            response.setCharacterEncoding("UTF-8");
+                            response.setStatus(HttpServletResponse.SC_OK);
+
+                            response.getWriter().write(new ObjectMapper().writeValueAsString(logoutResponse));
                             response.getWriter().flush();
                         })
                         .permitAll()
@@ -41,13 +47,5 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public BearerTokenResolver bearerTokenResolver() {
-        DefaultBearerTokenResolver resolver = new DefaultBearerTokenResolver();
-        resolver.setAllowFormEncodedBodyParameter(true);
-        resolver.setAllowUriQueryParameter(true);
-        return resolver;
     }
 }

--- a/src/main/java/umc/puppymode/config/security/SecurityConfig.java
+++ b/src/main/java/umc/puppymode/config/security/SecurityConfig.java
@@ -19,8 +19,9 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain (HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/auth/kakao/login", "/auth/apple/login", "/auth/logout").permitAll()
-                        .anyRequest().authenticated()
+//                        .requestMatchers("/auth/kakao/login", "/auth/apple/login", "/auth/logout").permitAll()
+//                        .anyRequest().authenticated()
+                                .anyRequest().permitAll()
                 )
                 .csrf(csrf -> csrf.disable())
 //                .oauth2ResourceServer(oauth2 -> oauth2

--- a/src/main/java/umc/puppymode/config/security/UserAuthentication.java
+++ b/src/main/java/umc/puppymode/config/security/UserAuthentication.java
@@ -1,0 +1,14 @@
+package umc.puppymode.config.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    // 사용자 인증 객체 생성
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}

--- a/src/main/java/umc/puppymode/domain/User.java
+++ b/src/main/java/umc/puppymode/domain/User.java
@@ -2,13 +2,15 @@ package umc.puppymode.domain;
 
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import umc.puppymode.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/umc/puppymode/repository/UserRepository.java
+++ b/src/main/java/umc/puppymode/repository/UserRepository.java
@@ -3,7 +3,9 @@ package umc.puppymode.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.puppymode.domain.User;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/umc/puppymode/service/AuthService/KakaoService.java
+++ b/src/main/java/umc/puppymode/service/AuthService/KakaoService.java
@@ -1,4 +1,4 @@
-package umc.puppymode.service;
+package umc.puppymode.service.AuthService;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
@@ -44,11 +44,11 @@ public class KakaoService {
                 .bodyToMono(KakaoTokenResponseDTO.class)
                 .block();
 
-        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDTO.getAccessToken());
-        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDTO.getRefreshToken());
+//        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDTO.getAccessToken());
+//        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDTO.getRefreshToken());
         //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
-        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDTO.getIdToken());
-        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDTO.getScope());
+//        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDTO.getIdToken());
+//        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDTO.getScope());
 
         return kakaoTokenResponseDTO.getAccessToken();
     }
@@ -70,9 +70,9 @@ public class KakaoService {
                 .bodyToMono(KakaoUserInfoResponseDTO.class)
                 .block();
 
-        log.info("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
-        log.info("[ Kakao Service ] NickName ---> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
-        log.info("[ Kakao Service ] email ---> {} ", userInfo.getKakaoAccount().getEmail());
+//        log.info("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
+//        log.info("[ Kakao Service ] NickName ---> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
+//        log.info("[ Kakao Service ] email ---> {} ", userInfo.getKakaoAccount().getEmail());
 
         return userInfo;
     }

--- a/src/main/java/umc/puppymode/service/KakaoService.java
+++ b/src/main/java/umc/puppymode/service/KakaoService.java
@@ -72,7 +72,7 @@ public class KakaoService {
 
         log.info("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
         log.info("[ Kakao Service ] NickName ---> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
-        log.info("[ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.getKakaoAccount().getProfile().getProfileImageUrl());
+        log.info("[ Kakao Service ] email ---> {} ", userInfo.getKakaoAccount().getEmail());
 
         return userInfo;
     }

--- a/src/main/java/umc/puppymode/service/KakaoService.java
+++ b/src/main/java/umc/puppymode/service/KakaoService.java
@@ -1,0 +1,79 @@
+package umc.puppymode.service;
+
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import umc.puppymode.web.dto.KakaoTokenResponseDTO;
+import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+    private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+
+    public String getAccessTokenFromKakao(String code) {
+        KakaoTokenResponseDTO kakaoTokenResponseDTO = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoTokenResponseDTO.class)
+                .block();
+
+        log.info(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDTO.getAccessToken());
+        log.info(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDTO.getRefreshToken());
+        //제공 조건: OpenID Connect가 활성화 된 앱의 토큰 발급 요청인 경우 또는 scope에 openid를 포함한 추가 항목 동의 받기 요청을 거친 토큰 발급 요청인 경우
+        log.info(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDTO.getIdToken());
+        log.info(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDTO.getScope());
+
+        return kakaoTokenResponseDTO.getAccessToken();
+    }
+
+    public KakaoUserInfoResponseDTO getUserInfo(String accessToken) {
+
+        KakaoUserInfoResponseDTO userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/v2/user/me")
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                //TODO : Custom Exception
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
+                .bodyToMono(KakaoUserInfoResponseDTO.class)
+                .block();
+
+        log.info("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
+        log.info("[ Kakao Service ] NickName ---> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
+        log.info("[ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.getKakaoAccount().getProfile().getProfileImageUrl());
+
+        return userInfo;
+    }
+}

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
@@ -1,0 +1,8 @@
+package umc.puppymode.service.UserService;
+
+import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+import umc.puppymode.web.dto.LoginResponseDTO;
+
+public interface UserAuthService {
+    LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo);
+}

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
@@ -1,0 +1,44 @@
+package umc.puppymode.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.config.security.JwtTokenProvider;
+import umc.puppymode.config.security.UserAuthentication;
+import umc.puppymode.domain.User;
+import umc.puppymode.repository.UserRepository;
+import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+import umc.puppymode.web.dto.LoginResponseDTO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAuthServiceImpl implements UserAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo) {
+        User user = userRepository.findByEmail(userInfo.getKakaoAccount().getEmail())
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .email(userInfo.getKakaoAccount().getEmail())
+                            .username(userInfo.getKakaoAccount().getProfile().getNickName())
+                            .points(0)
+                            .receiveNotifications(false)
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+        // 현재 사용자 인증 객체 생성
+        Authentication authentication = new UserAuthentication(user.getUserId().toString(), null, null);
+
+        // JWT 토큰 생성
+        String token = jwtTokenProvider.generateToken(authentication);
+
+        // 응답 DTO 생성 및 반환
+        return new LoginResponseDTO(user.getUserId(), user.getUsername(), user.getEmail(), token, user.getPoints());
+    }
+}

--- a/src/main/java/umc/puppymode/service/UserService/UserCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserCommandServiceImpl.java
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.puppymode.apiPayload.code.status.ErrorStatus;
 import umc.puppymode.apiPayload.exception.GeneralException;
+import umc.puppymode.config.security.UserAuthentication;
 import umc.puppymode.domain.User;
 import umc.puppymode.repository.UserRepository;
+import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+import umc.puppymode.web.dto.LoginResponseDTO;
 import umc.puppymode.web.dto.UserRequestDTO;
 
 @Service

--- a/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.service.KakaoService;
+import umc.puppymode.service.AuthService.KakaoService;
 import umc.puppymode.service.UserService.UserAuthService;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 import umc.puppymode.web.dto.LoginResponseDTO;

--- a/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
@@ -1,0 +1,50 @@
+package umc.puppymode.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.service.KakaoService;
+import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/kakao")
+public class KakaoLoginController {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping("/callback")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+        try {
+            // 카카오에서 Access Token 가져오기
+            String accessToken = kakaoService.getAccessTokenFromKakao(code);
+            log.info("Received authorization code: {}", code);
+
+            // 사용자 정보 가져오기
+            KakaoUserInfoResponseDTO userInfo = kakaoService.getUserInfo(accessToken);
+
+            //TODO: null 검사 후 response 파싱하여 로그인/회원가입 로직 추가. 자체 jwt 토큰으로 인가해야함.
+            // 카카오 리턴 id 를 식별자로 사용.
+            // db에 id 존재하면 로그인, 없으면 회원가입 진행.
+            // password: null, auth id 만 추가하여 회원가입.
+
+            // 성공 응답 반환
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (Exception e) {
+            log.error("카카오 로그인 오류 발생: {}", e.getMessage(), e);
+
+            // 실패 응답 반환
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+//                    "message", "카카오 로그인 오류가 발생했습니다.",
+//                    "error", e.getMessage()
+//            ));
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
@@ -8,8 +8,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.service.KakaoService;
+import umc.puppymode.service.UserService.UserAuthService;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
+import umc.puppymode.web.dto.LoginResponseDTO;
 
 @Slf4j
 @RestController
@@ -18,9 +21,10 @@ import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 public class KakaoLoginController {
 
     private final KakaoService kakaoService;
+    private final UserAuthService userAuthService;
 
     @GetMapping("/callback")
-    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> callback(@RequestParam("code") String code) {
         try {
             // 카카오에서 Access Token 가져오기
             String accessToken = kakaoService.getAccessTokenFromKakao(code);
@@ -29,22 +33,30 @@ public class KakaoLoginController {
             // 사용자 정보 가져오기
             KakaoUserInfoResponseDTO userInfo = kakaoService.getUserInfo(accessToken);
 
-            //TODO: null 검사 후 response 파싱하여 로그인/회원가입 로직 추가. 자체 jwt 토큰으로 인가해야함.
-            // 카카오 리턴 id 를 식별자로 사용.
-            // db에 id 존재하면 로그인, 없으면 회원가입 진행.
-            // password: null, auth id 만 추가하여 회원가입.
+            // 사용자 정보 유효성 검사
+            if (userInfo.getKakaoAccount().getProfile().getNickName() == null) {
+                throw new IllegalArgumentException("닉네임이 존재하지 않습니다.");
+            }
+
+            if (userInfo.getKakaoAccount().getEmail() == null) {
+                throw new IllegalArgumentException("이메일이 존재하지 않습니다.");
+            }
+
+            // 로그인 또는 회원가입 처리
+            LoginResponseDTO loginResponse = userAuthService.createOrUpdateUser(userInfo);
 
             // 성공 응답 반환
-            return new ResponseEntity<>(HttpStatus.OK);
+            return ResponseEntity.ok(ApiResponse.onSuccess(loginResponse));
         } catch (Exception e) {
             log.error("카카오 로그인 오류 발생: {}", e.getMessage(), e);
 
             // 실패 응답 반환
-//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
-//                    "message", "카카오 로그인 오류가 발생했습니다.",
-//                    "error", e.getMessage()
-//            ));
+            ApiResponse<LoginResponseDTO> errorResponse = ApiResponse.onFailure(
+                    "AUTH_ERROR",
+                    "카카오 로그인 오류가 발생했습니다.",
+                    null
+            );
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/KakaoTokenResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/KakaoTokenResponseDTO.java
@@ -1,0 +1,26 @@
+package umc.puppymode.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDTO {
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("id_token")
+    public String idToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/umc/puppymode/web/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/KakaoUserInfoResponseDTO.java
@@ -1,0 +1,190 @@
+package umc.puppymode.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDTO {
+
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+
+    //자동 연결 설정을 비활성화한 경우만 존재.
+    //true : 연결 상태, false : 연결 대기 상태
+    @JsonProperty("has_signed_up")
+    public Boolean hasSignedUp;
+
+    //서비스에 연결 완료된 시각. UTC
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    //카카오싱크 간편가입을 통해 로그인한 시각. UTC
+    @JsonProperty("synched_at")
+    public Date synchedAt;
+
+    //사용자 프로퍼티
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    //uuid 등 추가 정보
+    @JsonProperty("for_partner")
+    public Partner partner;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+
+        //프로필 정보 제공 동의 여부
+        @JsonProperty("profile_needs_agreement")
+        public Boolean isProfileAgree;
+
+        //닉네임 제공 동의 여부
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean isNickNameAgree;
+
+        //프로필 사진 제공 동의 여부
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean isProfileImageAgree;
+
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+        //이름 제공 동의 여부
+        @JsonProperty("name_needs_agreement")
+        public Boolean isNameAgree;
+
+        //카카오계정 이름
+        @JsonProperty("name")
+        public String name;
+
+        //이메일 제공 동의 여부
+        @JsonProperty("email_needs_agreement")
+        public Boolean isEmailAgree;
+
+        //이메일이 유효 여부
+        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+        @JsonProperty("is_email_valid")
+        public Boolean isEmailValid;
+
+        //이메일이 인증 여부
+        //true : 인증된 이메일, false : 인증되지 않은 이메일
+        @JsonProperty("is_email_verified")
+        public Boolean isEmailVerified;
+
+        //카카오계정 대표 이메일
+        @JsonProperty("email")
+        public String email;
+
+        //연령대 제공 동의 여부
+        @JsonProperty("age_range_needs_agreement")
+        public Boolean isAgeAgree;
+
+        //연령대
+        //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        @JsonProperty("age_range")
+        public String ageRange;
+
+        //출생 연도 제공 동의 여부
+        @JsonProperty("birthyear_needs_agreement")
+        public Boolean isBirthYearAgree;
+
+        //출생 연도 (YYYY 형식)
+        @JsonProperty("birthyear")
+        public String birthYear;
+
+        //생일 제공 동의 여부
+        @JsonProperty("birthday_needs_agreement")
+        public Boolean isBirthDayAgree;
+
+        //생일 (MMDD 형식)
+        @JsonProperty("birthday")
+        public String birthDay;
+
+        //생일 타입
+        // SOLAR(양력) 혹은 LUNAR(음력)
+        @JsonProperty("birthday_type")
+        public String birthDayType;
+
+        //성별 제공 동의 여부
+        @JsonProperty("gender_needs_agreement")
+        public Boolean isGenderAgree;
+
+        //성별
+        @JsonProperty("gender")
+        public String gender;
+
+        //전화번호 제공 동의 여부
+        @JsonProperty("phone_number_needs_agreement")
+        public Boolean isPhoneNumberAgree;
+
+        //전화번호
+        //국내 번호인 경우 +82 00-0000-0000 형식
+        @JsonProperty("phone_number")
+        public String phoneNumber;
+
+        //CI 동의 여부
+        @JsonProperty("ci_needs_agreement")
+        public Boolean isCIAgree;
+
+        //CI, 연계 정보
+        @JsonProperty("ci")
+        public String ci;
+
+        //CI 발급 시각, UTC
+        @JsonProperty("ci_authenticated_at")
+        public Date ciCreatedAt;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+
+            //프로필 미리보기 이미지 URL
+            @JsonProperty("thumbnail_image_url")
+            public String thumbnailImageUrl;
+
+            //프로필 사진 URL
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+
+            //프로필 사진 URL 기본 프로필인지 여부
+            //true : 기본 프로필, false : 사용자 등록
+            @JsonProperty("is_default_image")
+            public String isDefaultImage;
+
+            //닉네임이 기본 닉네임인지 여부
+            //true : 기본 닉네임, false : 사용자 등록
+            @JsonProperty("is_default_nickname")
+            public Boolean isDefaultNickName;
+
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/dto/LoginResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/LoginResponseDTO.java
@@ -1,0 +1,18 @@
+package umc.puppymode.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponseDTO {
+    private Long userId;
+    private String username;
+    private String email;
+    private String token;
+    private Integer points;
+}


### PR DESCRIPTION
# 🚀 개요
Spring security, kakao 로그인, jwt 구현

## 📌 관련 이슈번호
- closed #12

## ⏳ 작업 내용
- **`application.yml` 업데이트**
- Spring security :  `config.security` 패키지에 구현
- kakao 로그인 : kakao로부터 access token 발급, 유저 정보 받아옴
- jwt : `config.security` 패키지에 구현. 
  - authentication 객체 생성 -> userId 사용하여 jwt 생성

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 추후 refresh token 사용 로직 추가해야 함.