### PR TITLE
[FEAT] 강아지 아이템 API 수정 #34

### DIFF
--- a/src/main/java/umc/puppymode/domain/EquippedItemImage.java
+++ b/src/main/java/umc/puppymode/domain/EquippedItemImage.java
@@ -1,0 +1,29 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import umc.puppymode.domain.common.BaseEntity;
+import umc.puppymode.domain.enums.PuppyType;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "equipped_item_image")
+public class EquippedItemImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+
+    @Enumerated(EnumType.STRING)
+    private PuppyType puppyType; // 강아지 타입
+
+    private String levelName; // 강아지 레벨 이름
+
+    private Long itemId; // 아이템 아이디
+
+    private String imageUrl; // 착용 이미지 URL
+}
+
+

--- a/src/main/java/umc/puppymode/domain/PuppyItem.java
+++ b/src/main/java/umc/puppymode/domain/PuppyItem.java
@@ -24,4 +24,8 @@ public class PuppyItem extends BaseEntity {
     private String itemName; // 아이템 이름
     private String imageUrl; // 아이템 이미지 URL
     private Integer price; // 아이템 가격
+
+    private Boolean isPurchased; // 구매 여부
+
+    private Boolean mission_item; // 도전 과제 보상 아이템 여부
 }

--- a/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
+++ b/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import jakarta.persistence.*;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.PuppyItemCategory;
 
 import java.time.LocalDateTime;
 
@@ -24,6 +25,10 @@ public class PuppyCustomization {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private PuppyItem puppyItem;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private PuppyItemCategory puppyItemCategory;
 
     private Boolean isEquipped; // 아이템 장착 여부
 

--- a/src/main/java/umc/puppymode/repository/EquippedItemImageRepository.java
+++ b/src/main/java/umc/puppymode/repository/EquippedItemImageRepository.java
@@ -1,0 +1,27 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import umc.puppymode.domain.EquippedItemImage;
+import umc.puppymode.domain.enums.PuppyType;
+
+import java.util.Optional;
+
+@Repository
+public interface EquippedItemImageRepository extends JpaRepository<EquippedItemImage, Long> {
+    /**
+     * 강아지 타입, 레벨 이름, 아이템 카테고리에 따라 착용 이미지를 조회합니다.
+     *
+     * @param puppyType 강아지 타입
+     * @param levelName 강아지 레벨 이름
+     * @param itemId 아이템 아이디
+     * @return imageUrl
+     */
+    Optional<EquippedItemImage> findByPuppyTypeAndLevelNameAndItemId(
+            PuppyType puppyType,
+            String levelName,
+            Long itemId
+    );
+}
+

--- a/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
@@ -3,6 +3,7 @@ package umc.puppymode.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.PuppyItemCategory;
 import umc.puppymode.domain.mapping.PuppyCustomization;
 
 import java.util.Optional;
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface PuppyCustomizationRepository extends JpaRepository<PuppyCustomization, Long> {
     boolean existsByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
     Optional<PuppyCustomization> findByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
+    Optional<PuppyCustomization> findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(Puppy puppy, PuppyItemCategory puppyItemCategory);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
@@ -1,10 +1,5 @@
 package umc.puppymode.service.PuppyService;
 
-import umc.puppymode.domain.User;
-import umc.puppymode.web.dto.ItemCategoryResponseDto;
-import umc.puppymode.web.dto.ItemResponseDto;
-
-import java.util.List;
 import java.util.Map;
 
 public interface PuppyItemService {

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -5,13 +5,15 @@ import org.springframework.stereotype.Service;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyItem;
 import umc.puppymode.domain.PuppyItemCategory;
+import umc.puppymode.domain.EquippedItemImage;
 import umc.puppymode.domain.mapping.PuppyCustomization;
 import umc.puppymode.repository.*;
 import umc.puppymode.web.dto.EquippedItemInfoDTO;
-import umc.puppymode.web.dto.ItemCategoryResponseDto;
-import umc.puppymode.web.dto.ItemResponseDto;
+import umc.puppymode.web.dto.ItemCategoryResponseDTO;
 import umc.puppymode.domain.User;
+import umc.puppymode.web.dto.ItemResponseDTO;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,14 +28,16 @@ public class PuppyItemServiceImpl implements PuppyItemService {
     private final UserRepository userRepository;
     private final PuppyCustomizationRepository puppyCustomizationRepository;
     private final PuppyRepository puppyRepository;
+    private final EquippedItemImageRepository equippedItemImageRepository;
+
 
     @Override
     public Map<String, Object> getAllCategories() {
         // 전체 카테고리 수
         Long totalCategoryCount = categoryRepository.count();
 
-        List<ItemCategoryResponseDto> categories = categoryRepository.findAll().stream()
-                .map(category -> new ItemCategoryResponseDto(
+        List<ItemCategoryResponseDTO> categories = categoryRepository.findAll().stream()
+                .map(category -> new ItemCategoryResponseDTO(
                         category.getCategoryId(),
                         category.getCategoryName(),
                         itemRepository.countByCategory_CategoryId(category.getCategoryId()) // 카테고리 별 아이템 수
@@ -52,11 +56,14 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         // 해당 카테고리의 아이템 목록
         List<PuppyItem> items = itemRepository.findAllByCategory_CategoryId(categoryId);
 
-        List<ItemResponseDto> itemResponseList = items.stream()
-                .map(item -> new ItemResponseDto(
+        List<ItemResponseDTO> itemResponseList = items.stream()
+                .map(item -> new ItemResponseDTO(
                         item.getItemId(),
                         item.getItemName(),
-                        item.getPrice()
+                        item.getPrice(),
+                        item.getImageUrl(),
+                        item.getIsPurchased(),
+                        item.getMission_item()
                 ))
                 .collect(Collectors.toList());
 
@@ -85,10 +92,16 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         if (!item.getCategory().getCategoryId().equals(categoryId)) {
             throw new IllegalArgumentException("아이템이 해당 카테고리에 속하지 않습니다.");
         }
+        PuppyItemCategory puppyItemCategory = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
 
-        // 이미 구매된 아이템인지 확인
-        boolean alreadyPurchased = puppyCustomizationRepository.existsByPuppyAndPuppyItem(puppy, item);
-        if (alreadyPurchased) {
+        // 도전 과제 보상 아이템 확인
+        if (item.getMission_item()) {
+            throw new IllegalArgumentException("도전 과제로 얻는 아이템은 구매할 수 없습니다.");
+        }
+
+        // 아이템 구매 여부 확인
+        if (item.getIsPurchased()) {
             throw new IllegalArgumentException("이미 구매한 아이템입니다.");
         }
 
@@ -99,10 +112,14 @@ public class PuppyItemServiceImpl implements PuppyItemService {
 
         // 포인트 차감 및 아이템 구매 처리
         user.setPoints(user.getPoints() - item.getPrice());
+        item.setIsPurchased(true);
+        itemRepository.save(item);
         PuppyCustomization customization = new PuppyCustomization();
         customization.setPuppy(puppy);
         customization.setPuppyItem(item);
+        customization.setPuppyItemCategory(puppyItemCategory);
         customization.setIsEquipped(false); // 기본값은 장착되지 않은 상태
+        customization.setCreatedAt(LocalDateTime.now());
         puppyCustomizationRepository.save(customization);
 
         // 저장
@@ -134,29 +151,41 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         if (!item.getCategory().getCategoryId().equals(categoryId)) {
             throw new IllegalArgumentException("아이템이 해당 카테고리에 속하지 않습니다.");
         }
+        PuppyItemCategory puppyItemCategory = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
 
         // 아이템 구매 여부 확인
         PuppyCustomization customization = puppyCustomizationRepository.findByPuppyAndPuppyItem(puppy, item)
-                .orElseThrow(() -> new IllegalArgumentException("강아지에게 해당 아이템이 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("구매하지 않은 아이템입니다."));
 
-        // 이미 착용 중인 아이템인지 확인
-        if (customization.getIsEquipped()) {
-            throw new IllegalArgumentException("이미 착용한 아이템입니다.");
+
+        // 같은 카테고리에서 현재 착용 중인 아이템 해제
+        PuppyCustomization currentEquippedItem = puppyCustomizationRepository.findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(puppy, puppyItemCategory)
+                .orElse(null);
+        if (currentEquippedItem != null) {
+            currentEquippedItem.setIsEquipped(false);
+            puppyCustomizationRepository.save(currentEquippedItem);
         }
 
         // 아이템 착용 처리
         customization.setIsEquipped(true);
+        customization.setUpdatedAt(LocalDateTime.now());
         puppyCustomizationRepository.save(customization);
 
-        // 강아지 이미지 갱신 (추후에 강아지의 이미지 URL을 업데이트하는 로직을 추가)
-        String updatedImageUrl = "";
+        // 아이템 착용 이미지
+        String updatedImageUrl = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
+                puppy.getPuppyLevel().getPuppyType(),
+                puppy.getPuppyLevel().getLevelName(),
+                itemId
+        ).map(EquippedItemImage::getImageUrl)
+                .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
 
         // 응답 데이터 구성
-        Map<String, Object> response = new HashMap<>();
-        response.put("updatedPuppyImageUrl", updatedImageUrl);
-        response.put("equippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
+        Map<String, Object> result = new HashMap<>();
+        result.put("updatedPuppyImageUrl", updatedImageUrl);
+        result.put("equippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
 
-        return response;
+        return result;
     }
 
     // 유저 구현

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 //import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import umc.puppymode.domain.User;
 import umc.puppymode.service.PuppyService.PuppyItemService;
-import umc.puppymode.web.dto.ItemCategoryResponseDto;
-import umc.puppymode.web.dto.ItemResponseDto;
 import umc.puppymode.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 
@@ -64,6 +61,7 @@ public class PuppyItemController {
         Map<String, Object> result = puppyItemService.equipItem(categoryId, itemId, userId);
         return new ApiResponse<>(true, "SUCCESS_EQUIP_PUPPY_ITEM", "아이템 착용 성공", result);
     }
+
     // 유저 구현
 //    @Operation(summary = "아이템 구매 API", description = "아이템을 구매하고 잔여 포인트와 아이템 ID를 반환하는 API")
 //    @PostMapping("/{categoryId}/items/{itemId}")

--- a/src/main/java/umc/puppymode/web/dto/ItemCategoryResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/ItemCategoryResponseDTO.java
@@ -7,9 +7,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class ItemCategoryResponseDto {
+public class ItemCategoryResponseDTO {
     private Long categoryId; // 카테고리 ID
     private String name; // 카테고리 이름
     private Long itemCount; // 아이템 수
 }
-

--- a/src/main/java/umc/puppymode/web/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/ItemResponseDTO.java
@@ -8,8 +8,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
-public class ItemResponseDto {
+public class ItemResponseDTO {
     private Long itemId; // 아이템 ID
     private String name; // 아이템 이름
     private Integer price; // 아이템 가격
+    private String image_url; // 아이템 이미지
+    private Boolean isPurchased; // 아이템 구매 여부
+    private Boolean mission_item; // 도전 과제 보상 아이템 여부
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
강아지 아이템 API 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #34

## ⏳ 작업 내용
- 동일 카테고리의 아이템 중복 착용 막는 로직 추가
- 도전 과제 아이템 구매 불가 로직 추가
- 아이템 착용 시 착용 이미지 보냄

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
