### PR TITLE
[Feat] 강아지 랜덤 선택 기능 수정 #32

### DIFF
--- a/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
+++ b/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
@@ -1,14 +1,17 @@
 package umc.puppymode.converter;
 
 import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyLevel;
+import umc.puppymode.domain.User;
 import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
 
 public class MainPuppyConverter {
 
-    public static MainPuppyResDTO.RandomPuppyViewDTO toRandomPuppyViewDTO(String type, String imageUrl) {
+    public static MainPuppyResDTO.RandomPuppyViewDTO toRandomPuppyViewDTO(Puppy puppy) {
         return MainPuppyResDTO.RandomPuppyViewDTO.builder()
-                .puppyType(type)
-                .puppyImageUrl(imageUrl)
+                .userId(puppy.getUser().getUserId())
+                .puppyType(puppy.getPuppyLevel().getPuppyType().getType())
+                .puppyImageUrl(puppy.getPuppyLevel().getLevelImageUrl())
                 .build();
     }
 
@@ -18,7 +21,7 @@ public class MainPuppyConverter {
                 .puppyName(puppy.getPuppyName())
                 .level(puppy.getPuppyLevel().getPuppyLevel())
                 .levelName(puppy.getPuppyLevel().getLevelName())
-                .imageUrl(puppy.getPuppyImageUrl())
+                .imageUrl(puppy.getPuppyLevel().getLevelImageUrl())
                 .levelMinExp(puppy.getPuppyLevel().getLevelMinExp())
                 .levelMaxExp(puppy.getPuppyLevel().getLevelMaxEXP())
                 .puppyExp(puppy.getPuppyExp())
@@ -31,6 +34,14 @@ public class MainPuppyConverter {
                 .levelMinExp(puppy.getPuppyLevel().getLevelMinExp())
                 .levelMaxExp(puppy.getPuppyLevel().getLevelMaxEXP())
                 .puppyExp(puppy.getPuppyExp())
+                .build();
+    }
+
+    public static Puppy toPuppy(PuppyLevel puppyLevel, User user) {
+        return Puppy.builder()
+                .user(user)
+                .puppyLevel(puppyLevel)
+                .puppyExp(0)
                 .build();
     }
 }

--- a/src/main/java/umc/puppymode/domain/Puppy.java
+++ b/src/main/java/umc/puppymode/domain/Puppy.java
@@ -1,14 +1,16 @@
 package umc.puppymode.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import umc.puppymode.domain.common.BaseEntity;
 import umc.puppymode.domain.enums.CustomizingItem;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Puppy extends BaseEntity {
 
     @Id
@@ -23,7 +25,6 @@ public class Puppy extends BaseEntity {
     @JoinColumn(name = "puppy_level_id")
     private PuppyLevel puppyLevel;
 
-    private String puppyImageUrl;
     private String puppyName;
     private Integer puppyExp;
 

--- a/src/main/java/umc/puppymode/repository/PuppyLevelRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyLevelRepository.java
@@ -1,0 +1,11 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.PuppyLevel;
+
+import java.util.List;
+
+public interface PuppyLevelRepository extends JpaRepository<PuppyLevel, Long> {
+
+    List<PuppyLevel> findByPuppyLevel(Integer puppyLevel);
+}

--- a/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
@@ -57,7 +57,7 @@ public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
                                     .token(token)
                                     .title("오늘도 " + puppy.getPuppyName() + "랑 놀아주세요.")
                                     .body(puppy.getPuppyName() + "가 주인님을 애타게 기다리고 있어요.")
-                                    .image(puppy.getPuppyImageUrl())
+                                    .image(puppy.getPuppyLevel().getLevelImageUrl())
                                     .build()
                     );
                 } catch (Exception e) {

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
@@ -5,7 +5,7 @@ import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
 public interface MainPuppyCommandService {
     
     // 랜덤으로 강아지를 선택
-    MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy();
+    MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy(Long userId);
     // 강아지의 이름을 수정
     String updatePuppyName(Long puppyId, String newPuppyName);
     // 강아지 놀아주기 실행

--- a/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
+++ b/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
@@ -18,9 +18,10 @@ public class MainPuppyController {
 
     @PostMapping
     @Operation(summary = "강아지 랜덤 선택 API", description = "강아지를 랜덤으로 선택하는 API입니다.")
-    public ApiResponse<MainPuppyResDTO.RandomPuppyViewDTO> getRandomPuppy() {
+    public ApiResponse<MainPuppyResDTO.RandomPuppyViewDTO> getRandomPuppy(
+            @RequestParam Long userId) {
 
-        MainPuppyResDTO.RandomPuppyViewDTO randomPuppyViewDTO = mainPuppyCommandService.getRandomPuppy();
+        MainPuppyResDTO.RandomPuppyViewDTO randomPuppyViewDTO = mainPuppyCommandService.getRandomPuppy(userId);
         return ApiResponse.onSuccess(randomPuppyViewDTO);
     }
 

--- a/src/main/java/umc/puppymode/web/dto/MainPuppyDTO/MainPuppyResDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/MainPuppyDTO/MainPuppyResDTO.java
@@ -9,6 +9,7 @@ public class MainPuppyResDTO {
     @Builder
     // 온보딩 화면에 보여지는 랜덤선택된 강아지의 정보
     public static class RandomPuppyViewDTO {
+        private Long userId;
         private String puppyType;
         private String puppyImageUrl;
     }


### PR DESCRIPTION
# 🚀 개요
- 랜덤 선택 api 내에서 puppy 객체와 user 객체 연결까지 한번에 진행하게끔 수정
- 놀아주기 기능 증가 퍼센트 5% -> 1%로 변경

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #32 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
