### PR TITLE
[REFACTOR] 알림 수신 여부 관련 API에서 JWT로 user id 추출 #40

### DIFF
--- a/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
@@ -5,4 +5,5 @@ import umc.puppymode.web.dto.LoginResponseDTO;
 
 public interface UserAuthService {
     LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo);
+    Long getCurrentUserId();
 }

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
@@ -2,8 +2,11 @@ package umc.puppymode.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.GeneralException;
 import umc.puppymode.config.security.JwtTokenProvider;
 import umc.puppymode.config.security.UserAuthentication;
 import umc.puppymode.domain.User;
@@ -40,5 +43,24 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         // 응답 DTO 생성 및 반환
         return new LoginResponseDTO(user.getUserId(), user.getUsername(), user.getEmail(), token, user.getPoints());
+    }
+
+    @Override
+    public Long getCurrentUserId() {
+
+        // 인증 객체를 SecurityContext에서 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증 정보가 없거나 인증 객체가 UserAuthentication 타입이 아닌 경우 예외 발생
+        if (authentication == null || !(authentication instanceof UserAuthentication)) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        // 인증된 사용자 정보가 있으면, 그 사용자 ID를 반환
+        try {
+            return Long.valueOf(authentication.getPrincipal().toString());
+        } catch (NumberFormatException e) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/UserController.java
+++ b/src/main/java/umc/puppymode/web/controller/UserController.java
@@ -1,11 +1,11 @@
 package umc.puppymode.web.controller;
 
-
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.UserService.UserAuthService;
 import umc.puppymode.service.UserService.UserCommandService;
 import umc.puppymode.service.UserService.UserQueryService;
 import umc.puppymode.web.dto.UserRequestDTO;
@@ -18,13 +18,14 @@ public class UserController {
 
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
+    private final UserAuthService userAuthService;
+
 
     @GetMapping("/notifications")
     @Operation(summary = "알림 수신 여부 조회 API", description = "사용자의 알림 수신 여부를 조회하는 API입니다.")
     public ResponseEntity<ApiResponse<UserResponseDTO>> getNotificationPreference() {
 
-        // 추후 JWT 인증 적용 후 변경 예정
-        Long userId = 1L;
+        Long userId = userAuthService.getCurrentUserId();
 
         UserResponseDTO responseDTO = userQueryService.getUserNotificationStatus(userId);
 
@@ -36,8 +37,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserResponseDTO>> updateNotificationPreference(
             @RequestBody UserRequestDTO requestDTO) {
 
-        // 추후 JWT 인증 적용 후 변경 예정
-        Long userId = 1L;
+        Long userId = userAuthService.getCurrentUserId();
 
         userCommandService.updateUserNotificationStatus(userId, requestDTO);
 
@@ -45,5 +45,4 @@ public class UserController {
 
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDto));
     }
-
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
알림 수신 여부 조회 & 수정 API에서 JWT로 user id를 추출하도록 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #40 

## ⏳ 작업 내용
- 알림 수신 여부 조회 & 수정 API에서 기존의 하드코딩된 user id를 JWT에서 추출하는 로직으로 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
