### PR TITLE
[FEAT] 음주 기록 관련 API 구현 #30

### DIFF
--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -50,8 +50,10 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_FILE_UPLOAD(HttpStatus.BAD_REQUEST, "IMAGE4002", "파일이 비어있거나 유효하지 않습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE500", "파일 업로드에 실패했습니다"),
     IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "해당 이름의 이미지가 버킷에 존재하지 않습니다."),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE500", "이미지를 버킷에서 삭제하는데 실패했습니다.")
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMAGE500", "이미지를 버킷에서 삭제하는데 실패했습니다."),
 
+    // 음주 기록 관련 예외 처리
+    DRINK_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "DRINK4001", "해당 ID의 주종을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/umc/puppymode/domain/DrinkHistory.java
+++ b/src/main/java/umc/puppymode/domain/DrinkHistory.java
@@ -1,0 +1,33 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.puppymode.domain.common.BaseEntity;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrinkHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long drinkHistoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToMany
+    @JoinTable(
+            name = "drink_history_hangover",
+            joinColumns = @JoinColumn(name = "history_id"),
+            inverseJoinColumns = @JoinColumn(name = "hangover_id")
+    )
+    private List<HangoverItem> hangovers;
+
+    private LocalDate drinkDate;
+    private Float drinkAmount;
+}

--- a/src/main/java/umc/puppymode/domain/DrinkHistoryItem.java
+++ b/src/main/java/umc/puppymode/domain/DrinkHistoryItem.java
@@ -1,0 +1,29 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.puppymode.domain.common.BaseEntity;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DrinkHistoryItem extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long historyItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "drink_history_id", nullable = false)
+    private DrinkHistory history;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private DrinkItem item;
+
+    private String unit;
+    private Float value;
+    private Float safetyValue;
+    private Float maxValue;
+
+}

--- a/src/main/java/umc/puppymode/domain/Feed.java
+++ b/src/main/java/umc/puppymode/domain/Feed.java
@@ -15,10 +15,6 @@ public class Feed extends BaseEntity {
     private Long feedId;
 
     @OneToOne
-    @JoinColumn(name = "puppy_id")
-    private Puppy puppy;
-
-    @OneToOne
     @JoinColumn(name = "drink_history_id")
     private DrinkHistory drinkHistory;
 

--- a/src/main/java/umc/puppymode/domain/Feed.java
+++ b/src/main/java/umc/puppymode/domain/Feed.java
@@ -1,0 +1,27 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.puppymode.domain.common.BaseEntity;
+import umc.puppymode.domain.enums.FeedingItem;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Feed extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long feedId;
+
+    @OneToOne
+    @JoinColumn(name = "puppy_id")
+    private Puppy puppy;
+
+    @OneToOne
+    @JoinColumn(name = "drink_history_id")
+    private DrinkHistory drinkHistory;
+
+    private String feedingType;
+    private String feedImageUrl;
+}

--- a/src/main/java/umc/puppymode/domain/enums/FeedingItem.java
+++ b/src/main/java/umc/puppymode/domain/enums/FeedingItem.java
@@ -1,24 +1,25 @@
 package umc.puppymode.domain.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum FeedingItem {
-    CHICKEN("닭 고기"),
-    BEEF("소 고기"),
-    SALMON("연어"),
-    SWEET_POTATO("고구마"),
-    CARROT("당근"),
-    PUMPKIN("호박"),
-    BLUEBERRY("블루베리"),
-    BANANA("바나나"),
-    APPLE("사과"),
-    EGG("달걀");
+    CHICKEN("닭 고기", ""),
+    BEEF("소 고기", ""),
+    SALMON("연어", ""),
+    SWEET_POTATO("고구마", ""),
+    CARROT("당근", ""),
+    PUMPKIN("호박", ""),
+    BLUEBERRY("블루베리", ""),
+    BANANA("바나나", ""),
+    APPLE("사과", ""),
+    EGG("달걀", "");
 
     private final String description;
+    private final String imageUrl;
 
-    FeedingItem(String description) {
+    FeedingItem(String description, String imageUrl) {
         this.description = description;
-    }
-
-    public String getDescription() {
-        return description;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/umc/puppymode/repository/DrinkHistoryItemRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkHistoryItemRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.DrinkHistoryItem;
+
+public interface DrinkHistoryItemRepository extends JpaRepository<DrinkHistoryItem, Long> {
+}

--- a/src/main/java/umc/puppymode/repository/DrinkHistoryRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkHistoryRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.DrinkHistory;
+
+public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
+}

--- a/src/main/java/umc/puppymode/repository/DrinkItemRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkItemRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.DrinkItem;
+
+public interface DrinkItemRepository extends JpaRepository<DrinkItem, Long> {
+}

--- a/src/main/java/umc/puppymode/repository/FeedRepository.java
+++ b/src/main/java/umc/puppymode/repository/FeedRepository.java
@@ -1,0 +1,7 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.Feed;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandService.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandService.java
@@ -1,4 +1,8 @@
 package umc.puppymode.service.DrinkService;
 
+import umc.puppymode.web.dto.DrinkRequestDTO.*;
+import umc.puppymode.web.dto.DrinkResponseDTO.*;
+
 public interface DrinkCommandService {
+    DrinksRecordResponseDTO postDrinksRecord(Long userId, DrinkRecordDTO drinkRecordDTO);
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
@@ -83,7 +83,6 @@ public class DrinkCommandServiceImpl implements DrinkCommandService {
 
         Feed feed = new Feed();
         feed.setDrinkHistory(drinkHistory);
-        feed.setPuppy(puppy);
         feed.setFeedingType(type.getDescription());
         feed.setFeedImageUrl(type.getImageUrl());
 

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
@@ -3,9 +3,75 @@ package umc.puppymode.service.DrinkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.GeneralException;
+import umc.puppymode.domain.*;
+import umc.puppymode.repository.*;
+import umc.puppymode.web.dto.DrinkRequestDTO.*;
+import umc.puppymode.web.dto.DrinkResponseDTO.*;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class DrinkCommandServiceImpl implements DrinkCommandService {
+    private final UserRepository userRepository;
+    private final DrinkItemRepository drinkItemRepository;
+    private final DrinkHistoryRepository drinkHistoryRepository;
+    private final DrinkHistoryItemRepository drinkHistoryItemRepository;
+    private final HangoverRepository hangoverRepository;
+
+    @Override
+    public DrinksRecordResponseDTO postDrinksRecord(Long userId, DrinkRecordDTO drinkRecordDTO) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 기록 추가
+        DrinkHistory drinkHistory = new DrinkHistory();
+        drinkHistory.setUser(user);
+        drinkHistory.setDrinkDate(drinkRecordDTO.getDrinkDate());
+        // 마신 양 계산해서 합(잔, 병 합치기 필요)
+        drinkHistory.setDrinkAmount(drinkRecordDTO.getAlcoholTolerance().stream()
+                .map(AlcoholTolerance::getValue)
+                .reduce(0.0f, Float::sum));
+        drinkHistoryRepository.save(drinkHistory);
+
+        // 숙취 목록 추가
+        List<HangoverItem> hangoverItems = hangoverRepository.findAllById(drinkRecordDTO.getHangoverOptions());
+        if (!hangoverItems.isEmpty()) {
+            drinkHistory.setHangovers(hangoverItems);
+        }
+
+        // 주종 별 기록 추가
+        for (AlcoholTolerance tolerance : drinkRecordDTO.getAlcoholTolerance()) {
+            DrinkHistoryItem item = new DrinkHistoryItem();
+            DrinkItem drinkItem = drinkItemRepository.findById(tolerance.getDrinkItemId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.DRINK_ITEM_NOT_FOUND));;
+            item.setHistory(drinkHistory);
+            item.setItem(drinkItem);
+            item.setUnit(tolerance.getUnit());
+            item.setValue(tolerance.getValue());
+            drinkHistoryItemRepository.save(item);
+        }
+
+        DrinksRecordResponseDTO recordResponseDTO = new DrinksRecordResponseDTO();
+        // 숙취 개수에 따라 message 다르게
+        if (drinkRecordDTO.getHangoverOptions().toArray().length == 0) {
+            recordResponseDTO.setMessage("주량을 잘 조절해서 마셨네요!");
+        } else if (drinkRecordDTO.getHangoverOptions().toArray().length <= 2) {
+            recordResponseDTO.setMessage("다음에는 꼭 주량을 지키도록 노력해 주세요!");
+        } else {
+            recordResponseDTO.setMessage("건강을 생각해서 다음에는 꼭 주량을 지켜주세요!");
+        }
+
+        // 획득 먹이 10개 중 랜덤
+
+        recordResponseDTO.setFeed("랜덤으로 뽑은 먹이입니다!");
+        recordResponseDTO.setDogLevel(1L); // 예제 값
+        recordResponseDTO.setDogLevelName("초보 강아지");
+        recordResponseDTO.setDogPercent(75.0f); // 예제 값
+
+        return recordResponseDTO;
+    }
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
@@ -72,8 +72,8 @@ public class DrinkCommandServiceImpl implements DrinkCommandService {
 
         Puppy puppy = puppyRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));;
-        recordResponseDTO.setPuppyLevel(Long.valueOf(puppy.getPuppyLevel().getPuppyLevel()));
-        recordResponseDTO.setPuppyName(puppy.getPuppyName());
+        recordResponseDTO.setPuppyLevel(puppy.getPuppyLevel().getPuppyLevel());
+        recordResponseDTO.setPuppyLevelName(puppy.getPuppyLevel().getLevelName());
         recordResponseDTO.setPuppyPercent(puppy.getPuppyExp());
 
         // 획득 먹이 10개 중 랜덤

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkQueryServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class DrinkQueryServiceImpl implements DrinkQueryService {
 
     private final HangoverRepository hangoverRepository;

--- a/src/main/java/umc/puppymode/web/controller/DrinkController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkController.java
@@ -5,16 +5,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.DrinkService.DrinkCommandService;
 import umc.puppymode.service.DrinkService.DrinkQueryService;
+import umc.puppymode.web.dto.DrinkRequestDTO;
 import umc.puppymode.web.dto.DrinkResponseDTO.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/")
+@RequestMapping("/drinks")
 public class DrinkController {
 
+    private final DrinkCommandService drinkCommandService;
     private final DrinkQueryService drinkQueryService;
 
     @GetMapping("hangover")
@@ -24,17 +27,26 @@ public class DrinkController {
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
 
-    @GetMapping("drinks/categories")
+    @GetMapping("categories")
     @Operation(summary = "술 카테고리 조회 API", description = "술 카테고리를 조회하는 API입니다.")
     public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getDrinkCategories() {
         List<CategoryResponseDTO> responseDTO = drinkQueryService.getAllDrinkCategories();
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
 
-    @GetMapping("drinks/categories/{categoryId}")
+    @GetMapping("categories/{categoryId}")
     @Operation(summary = "카테고리 별 술 목록 조회 API", description = "카테고리 별 술 목록을 조회하는 API입니다.")
     public ResponseEntity<ApiResponse<DrinkItemsByCategoryResponseDTO>> getDrinksByCategory(@PathVariable Long categoryId) {
         DrinkItemsByCategoryResponseDTO responseDTO = drinkQueryService.getAllDrinkItemsByCategory(categoryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
+
+    @PostMapping("record")
+    @Operation(summary = "음주 기록 생성 API", description = "음주 기록을 생성하는 API입니다.")
+    public ResponseEntity<ApiResponse<DrinksRecordResponseDTO>> postDrinkRecord(@RequestBody DrinkRequestDTO.DrinkRecordDTO drinkRecordDTO) {
+        // 추후 JWT 인증 적용 후 변경 예정
+        Long userId = 1L;
+        DrinksRecordResponseDTO responseDTO = drinkCommandService.postDrinksRecord(userId, drinkRecordDTO);
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkRequestDTO.java
@@ -1,4 +1,32 @@
 package umc.puppymode.web.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
 public class DrinkRequestDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DrinkRecordDTO {
+        LocalDate drinkDate;
+        List<Long> hangoverOptions;
+        List<AlcoholTolerance> alcoholTolerance;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AlcoholTolerance {
+        private Long drinkCategoryId;
+        private Long drinkItemId;
+        private Float value;
+        private String unit;
+    }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -56,8 +56,8 @@ public class DrinkResponseDTO {
         private String message;
         private String feedImageUrl;
         private String feedType;
-        private Long puppyLevel;
-        private String puppyName;
+        private Integer puppyLevel;
+        private String puppyLevelName;
         private Integer puppyPercent;
     }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -46,4 +46,18 @@ public class DrinkResponseDTO {
         private String categoryName;
         private List<DrinksResponseDTO> items;
     }
+
+    @Builder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DrinksRecordResponseDTO {
+        private String message;
+        private String feedImageUrl;
+        private String feed;
+        private Long dogLevel;
+        private String dogLevelName;
+        private Float dogPercent;
+    }
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkResponseDTO.java
@@ -55,9 +55,9 @@ public class DrinkResponseDTO {
     public static class DrinksRecordResponseDTO {
         private String message;
         private String feedImageUrl;
-        private String feed;
-        private Long dogLevel;
-        private String dogLevelName;
-        private Float dogPercent;
+        private String feedType;
+        private Long puppyLevel;
+        private String puppyName;
+        private Integer puppyPercent;
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
음주 기록 생성 API 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #30 

## ⏳ 작업 내용
- 음주 기록 생성
- 음주 기록 생성 완료 시 랜덤 먹이 획득

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
