### PR TITLE
[Refactor] 메인강아지 및 컬렉션 JWT 사용 수정 #54

### DIFF
--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 강아지 관련 예외 처리
     PUPPY_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY404", "해당 ID를 가진 강아지를 찾을 수 없습니다."),
     UNAUTHORIZED_PUPPY_ACCESS(HttpStatus.UNAUTHORIZED, "PUPPY401", "강아지에 대한 접근 권한이 없습니다."),
+    PUPPY_ALREADY_EXISTS(HttpStatus.CONFLICT, "PUPPY409", "최대 강아지 보유량을 초과하였습니다. (최대: 1)"),
 
     // 이미지 관련 예외 처리
     EMPTY_FILE_LIST(HttpStatus.BAD_REQUEST, "IMAGE4001", "요청 파일 목록이 비어있습니다."),

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
@@ -7,7 +7,7 @@ public interface MainPuppyCommandService {
     // 랜덤으로 강아지를 선택
     MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy(Long userId);
     // 강아지의 이름을 수정
-    String updatePuppyName(Long puppyId, String newPuppyName);
+    String updatePuppyName(Long userId, Long puppyId, String newPuppyName);
     // 강아지 놀아주기 실행
     MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId, Long puppyId);
 }

--- a/src/main/java/umc/puppymode/web/controller/CollectionController.java
+++ b/src/main/java/umc/puppymode/web/controller/CollectionController.java
@@ -21,9 +21,9 @@ public class CollectionController {
     @GetMapping
     @Operation(summary = "컬렉션 조회 API", description = "컬렉션을 조회하는 API 입니다.")
     public ApiResponse<CollectionResDTO.CollectionListViewDTO> getCollections() {
-        
-        // 유저 아이디 얻는 방식 수정 예정
-        CollectionResDTO.CollectionListViewDTO collectionListViewDTO = collectionQueryService.getCollections(2L);
+
+        Long userId = userAuthService.getCurrentUserId();
+        CollectionResDTO.CollectionListViewDTO collectionListViewDTO = collectionQueryService.getCollections(userId);
         return ApiResponse.onSuccess(collectionListViewDTO);
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
+++ b/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.service.MainPuppyService.MainPuppyCommandService;
 import umc.puppymode.service.MainPuppyService.MainPuppyQueryService;
+import umc.puppymode.service.UserService.UserAuthService;
 import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
 
 @RestController
@@ -15,47 +16,44 @@ public class MainPuppyController {
 
     private final MainPuppyCommandService mainPuppyCommandService;
     private final MainPuppyQueryService mainPuppyQueryService;
+    private final UserAuthService userAuthService;
 
     @PostMapping
     @Operation(summary = "강아지 랜덤 선택 API", description = "강아지를 랜덤으로 선택하는 API입니다.")
-    public ApiResponse<MainPuppyResDTO.RandomPuppyViewDTO> getRandomPuppy(
-            @RequestParam Long userId) {
+    public ApiResponse<MainPuppyResDTO.RandomPuppyViewDTO> getRandomPuppy() {
 
+        Long userId = userAuthService.getCurrentUserId();
         MainPuppyResDTO.RandomPuppyViewDTO randomPuppyViewDTO = mainPuppyCommandService.getRandomPuppy(userId);
         return ApiResponse.onSuccess(randomPuppyViewDTO);
     }
 
-    // 추후에 유저 시큐리티 부분 구현되면, @CurrentUser와 같은 AuthUser를 사용하여 강아지 객체를 찾도록 수정 예정
     @GetMapping
     @Operation(summary = "사용자 강아지 정보 조회 API", description = "사용자의 강아지 정보를 조회하는 API입니다.")
-    public ApiResponse<MainPuppyResDTO.UserPuppyViewDTO> getUserPuppy(
-            @RequestParam Long userId) {
+    public ApiResponse<MainPuppyResDTO.UserPuppyViewDTO> getUserPuppy() {
 
+        Long userId = userAuthService.getCurrentUserId();
         MainPuppyResDTO.UserPuppyViewDTO userPuppyViewDTO = mainPuppyQueryService.getUserPuppy(userId);
         return ApiResponse.onSuccess(userPuppyViewDTO);
     }
 
-    // 이 api 역시 추후에 puppyId가 아닌 @CurrentUser 등을 사용하여 수정할 강아지 객체를 찾도록 수정 예정
     @PatchMapping
     @Operation(summary = "강아지 이름 수정 API", description = "강아지의 이름을 수정하는 API입니다.")
     public ApiResponse<String> updatePuppyName(
             @RequestParam Long puppyId,
             @RequestParam String newPuppyName) {
 
-        String updatedPuppyName = mainPuppyCommandService.updatePuppyName(puppyId, newPuppyName);
+        Long userId = userAuthService.getCurrentUserId();
+        String updatedPuppyName = mainPuppyCommandService.updatePuppyName(userId, puppyId, newPuppyName);
         return ApiResponse.onSuccess(updatedPuppyName);
     }
 
-    // 이 api도 @CurrentUser 등을 사용하여 유저 정보를 얻도록 수정 예정
     @PostMapping("/play")
     @Operation(summary = "강아지 놀아주기 API", description = "강아지 놀아주기를 실행하는 API입니다.")
     public ApiResponse<MainPuppyResDTO.PlayResDTO> playWithPuppy(
-            @RequestParam Long userId,
             @RequestParam Long puppyId) {
 
+        Long userId = userAuthService.getCurrentUserId();
         MainPuppyResDTO.PlayResDTO playResDTO = mainPuppyCommandService.platWithPuppy(userId, puppyId);
-
-        // 낙관적 업데이트 사용 시, 현재 리턴값인 playResDTO 내부의 값을 사용하여 유효성 판단
         return ApiResponse.onSuccess(playResDTO);
     }
 }


### PR DESCRIPTION
# 🚀 개요
- userId를 직접 받아오도록 구현된 부분을, jwt를 통해 얻을 수 있도록 수정
- MainPuppyCommandServiceImpl
    - updatePuppyName: 수정하려는 강아지에 대한 사용자의 권한 확인 및 에러처리 추가
    - getRandomPuppy: 사용자가 강아지 객체를 생성할 수 있는지 (소유한 강아지 객체가 없는지) 검증 및 에러 처리 추가

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #54 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
