### PR TITLE
Feature/#50 manage fcm token

### DIFF
--- a/src/main/java/umc/puppymode/config/AsyncConfig.java
+++ b/src/main/java/umc/puppymode/config/AsyncConfig.java
@@ -1,0 +1,16 @@
+package umc.puppymode.config;
+
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.context.annotation.Bean;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public ScheduledExecutorService scheduledExecutorService() {
+        return Executors.newScheduledThreadPool(1);
+    }
+}

--- a/src/main/java/umc/puppymode/config/AsyncConfig.java
+++ b/src/main/java/umc/puppymode/config/AsyncConfig.java
@@ -3,10 +3,13 @@ package umc.puppymode.config;
 import org.springframework.context.annotation.Configuration;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 @Configuration
+@EnableAsync
 public class AsyncConfig {
 
     @Bean

--- a/src/main/java/umc/puppymode/config/RestTemplateConfig.java
+++ b/src/main/java/umc/puppymode/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package umc.puppymode.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/umc/puppymode/domain/Token.java
+++ b/src/main/java/umc/puppymode/domain/Token.java
@@ -1,0 +1,28 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.puppymode.domain.common.BaseEntity;
+import umc.puppymode.domain.enums.TokenType;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Token extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tokenId;
+
+    private String token;
+
+    @Enumerated(EnumType.STRING)
+    private TokenType tokenType;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/umc/puppymode/domain/User.java
+++ b/src/main/java/umc/puppymode/domain/User.java
@@ -25,7 +25,6 @@ public class User extends BaseEntity {
     private String password;
     private Integer points;
     private Boolean receiveNotifications;
-    private String fcmToken;
 
     public void updatePoints(Integer points) {
         this.points += points;

--- a/src/main/java/umc/puppymode/domain/enums/TokenType.java
+++ b/src/main/java/umc/puppymode/domain/enums/TokenType.java
@@ -1,0 +1,6 @@
+package umc.puppymode.domain.enums;
+
+public enum TokenType {
+    JWT,
+    FCM
+}

--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -22,5 +22,8 @@ public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingApp
             "WHERE a.user = :user AND DATE(a.dateTime) = :date")
     boolean existsByUserAndDate(@Param("user") User user, @Param("date") LocalDate date);
 
-    List<DrinkingAppointment> findByStatus(AppointmentStatus status);
+    @Query("SELECT DISTINCT da FROM DrinkingAppointment da " +
+            "JOIN FETCH da.user " +
+            "WHERE da.status = :status")
+    List<DrinkingAppointment> findByStatusWithUser(@Param("status") AppointmentStatus status);
 }

--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -11,6 +11,7 @@ import umc.puppymode.domain.User;
 import umc.puppymode.domain.enums.AppointmentStatus;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingAppointment, Long> {
@@ -20,4 +21,6 @@ public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingApp
             "FROM DrinkingAppointment a " +
             "WHERE a.user = :user AND DATE(a.dateTime) = :date")
     boolean existsByUserAndDate(@Param("user") User user, @Param("date") LocalDate date);
+
+    List<DrinkingAppointment> findByStatus(AppointmentStatus status);
 }

--- a/src/main/java/umc/puppymode/repository/PuppyRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyRepository.java
@@ -13,6 +13,6 @@ public interface PuppyRepository extends JpaRepository<Puppy, Long> {
     Optional<Puppy> findByUser(User user);
   
     @Query("SELECT p FROM Puppy p WHERE p.user.userId = :userId")
-    Optional<Puppy> findByUserId(Long userId);
+    Optional<Puppy> findByUserId(@Param("userId")Long userId);
 }
 

--- a/src/main/java/umc/puppymode/repository/TokenRepository.java
+++ b/src/main/java/umc/puppymode/repository/TokenRepository.java
@@ -2,6 +2,7 @@ package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.puppymode.domain.Token;
 import umc.puppymode.domain.User;
 import umc.puppymode.domain.enums.TokenType;
@@ -10,6 +11,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+    @Query("SELECT t FROM Token t WHERE t.user IN :users AND t.tokenType = :tokenType")
+    List<Token> findByUsersAndTokenType(@Param("users") List<User> users, @Param("tokenType") TokenType tokenType);
+
     Optional<Token> findByUserAndTokenType(User user, TokenType tokenType);
 
     @Query("SELECT t.token FROM Token t WHERE t.tokenType = 'FCM' AND t.user.receiveNotifications = true")

--- a/src/main/java/umc/puppymode/repository/TokenRepository.java
+++ b/src/main/java/umc/puppymode/repository/TokenRepository.java
@@ -1,0 +1,12 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.Token;
+import umc.puppymode.domain.User;
+import umc.puppymode.domain.enums.TokenType;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByUserAndTokenType(User user, TokenType tokenType);
+}

--- a/src/main/java/umc/puppymode/repository/TokenRepository.java
+++ b/src/main/java/umc/puppymode/repository/TokenRepository.java
@@ -1,12 +1,19 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.puppymode.domain.Token;
 import umc.puppymode.domain.User;
 import umc.puppymode.domain.enums.TokenType;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
     Optional<Token> findByUserAndTokenType(User user, TokenType tokenType);
+
+    @Query("SELECT t.token FROM Token t WHERE t.tokenType = 'FCM' AND t.user.receiveNotifications = true")
+    List<String> findAllFcmTokensWithNotification();
+
+    Optional<Token> findByTokenAndTokenType(String token, TokenType tokenType);
 }

--- a/src/main/java/umc/puppymode/repository/UserRepository.java
+++ b/src/main/java/umc/puppymode/repository/UserRepository.java
@@ -1,21 +1,12 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import umc.puppymode.domain.User;
-import java.util.Optional;
-
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
   
     Optional<User> findByEmail(String email);
-
-    @Query("SELECT u.fcmToken FROM User u WHERE u.receiveNotifications = true")
-    List<String> findAllFcmTokensWithNotification();
-
-    Optional<User> findByFcmToken(String fcmToken);
 }

--- a/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
@@ -1,9 +1,9 @@
 package umc.puppymode.service.FcmService;
 
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMAppointmentResponseDTO;
 
 public interface FcmAppointmentService {
 
-    ApiResponse<FCMResponseDTO> scheduleDrinkingNotifications();
+    ApiResponse<FCMAppointmentResponseDTO> scheduleDrinkingNotifications();
 }

--- a/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
@@ -1,12 +1,9 @@
 package umc.puppymode.service.FcmService;
 
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.web.dto.FCMDTO.FCMAppointmentRequestDTO;
 import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 public interface FcmAppointmentService {
 
-    ApiResponse<FCMResponseDTO> scheduleDrinkingNotifications(
-            FCMAppointmentRequestDTO fcmAppointmentRequestDTO
-    );
+    ApiResponse<FCMResponseDTO> scheduleDrinkingNotifications();
 }

--- a/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentService.java
@@ -1,8 +1,8 @@
 package umc.puppymode.service.FcmService;
 
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.web.dto.FCMAppointmentRequestDTO;
-import umc.puppymode.web.dto.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMAppointmentRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 public interface FcmAppointmentService {
 

--- a/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmAppointmentServiceImpl.java
@@ -9,8 +9,8 @@ import umc.puppymode.domain.DrinkingAppointment;
 import umc.puppymode.repository.DrinkingAppointmentRepository;
 import umc.puppymode.util.DistanceCalculator;
 import umc.puppymode.util.RandomMessages;
-import umc.puppymode.web.dto.FCMAppointmentRequestDTO;
-import umc.puppymode.web.dto.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMAppointmentRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 import java.time.Duration;
 import java.time.ZoneId;

--- a/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeService.java
@@ -1,7 +1,7 @@
 package umc.puppymode.service.FcmService;
 
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.web.dto.FCMPlayResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMPlayResponseDTO;
 
 public interface FcmPlaytimeService {
 

--- a/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.List;
 public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
 
     private final FcmService fcmService;
+    private final FcmQueryService fcmQueryService;
     private final UserQueryService userQueryService;
 
     @Override
@@ -31,7 +32,7 @@ public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
     @Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul")
     public void sendScheduledPushNotification() {
         try {
-            List<String> fcmTokens = userQueryService.getAllFcmTokens();
+            List<String> fcmTokens = fcmQueryService.getAllFcmTokensWithNotification();
 
             // 토큰이 없으면 예외 처리
             if (fcmTokens.isEmpty()) {
@@ -41,15 +42,17 @@ public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
             // 모든 FCM 토큰에 대해 알림 발송
             for (String token : fcmTokens) {
                 try {
-                    User user = userQueryService.getUserByFcmToken(token);
+                    User user = fcmQueryService.getUserByFcmToken(token);
 
-                    // 사용자 정보 없으면 건너뛰기
-                    if (user == null) continue;
+                    if (user == null) {
+                        continue;
+                    }
 
                     Puppy puppy = userQueryService.getUserPuppy(user.getUserId());
 
-                    // 강아지 정보 없으면 건너뛰기
-                    if (puppy == null) continue;
+                    if (puppy == null) {
+                        continue;
+                    }
 
                     // 푸시 알림 발송
                     fcmService.sendMessageTo(
@@ -68,4 +71,5 @@ public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
             throw new GeneralException(ErrorStatus.FIREBASE_SCHEDULE_ERROR);
         }
     }
+
 }

--- a/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
@@ -8,8 +8,8 @@ import umc.puppymode.apiPayload.code.status.ErrorStatus;
 import umc.puppymode.apiPayload.exception.GeneralException;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.User;
-import umc.puppymode.web.dto.FCMPlayRequestDTO;
-import umc.puppymode.web.dto.FCMPlayResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMPlayRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMPlayResponseDTO;
 import umc.puppymode.service.UserService.UserQueryService;
 
 import java.util.List;

--- a/src/main/java/umc/puppymode/service/FcmService/FcmQueryService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmQueryService.java
@@ -1,0 +1,12 @@
+package umc.puppymode.service.FcmService;
+
+import umc.puppymode.domain.User;
+
+import java.util.List;
+
+public interface FcmQueryService {
+
+    List<String> getAllFcmTokensWithNotification();
+
+    User getUserByFcmToken(String token);
+}

--- a/src/main/java/umc/puppymode/service/FcmService/FcmQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package umc.puppymode.service.FcmService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.exception.GeneralException;
+import umc.puppymode.domain.Token;
+import umc.puppymode.domain.User;
+import umc.puppymode.repository.TokenRepository;
+import umc.puppymode.domain.enums.TokenType;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FcmQueryServiceImpl implements FcmQueryService {
+
+    private final TokenRepository tokenRepository;
+
+    // 모든 FCM 토큰 조회
+    @Override
+    public List<String> getAllFcmTokensWithNotification() {
+        return tokenRepository.findAllFcmTokensWithNotification();
+    }
+
+    // FCM 토큰으로 사용자 정보 조회
+    @Override
+    public User getUserByFcmToken(String token) {
+        if (token == null || token.isEmpty()) {
+            throw new GeneralException(ErrorStatus.FIREBASE_MISSING_TOKEN);
+        }
+
+        Token tokenEntity = tokenRepository.findByTokenAndTokenType(token, TokenType.FCM)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return tokenEntity.getUser();
+    }
+}

--- a/src/main/java/umc/puppymode/service/FcmService/FcmService.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmService.java
@@ -1,8 +1,8 @@
 package umc.puppymode.service.FcmService;
 
 import umc.puppymode.apiPayload.ApiResponse;
-import umc.puppymode.web.dto.FCMRequestDTO;
-import umc.puppymode.web.dto.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 public interface FcmService {
 

--- a/src/main/java/umc/puppymode/service/FcmService/FcmServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmServiceImpl.java
@@ -14,8 +14,8 @@ import org.springframework.web.client.RestTemplate;
 import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.apiPayload.code.status.ErrorStatus;
 import umc.puppymode.apiPayload.exception.GeneralException;
-import umc.puppymode.web.dto.FCMRequestDTO;
-import umc.puppymode.web.dto.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthService.java
@@ -6,4 +6,6 @@ import umc.puppymode.web.dto.LoginResponseDTO;
 public interface UserAuthService {
     LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo);
     Long getCurrentUserId();
+    LoginResponseDTO loginWithFcmToken(LoginResponseDTO loginResponseDTO, String fcmToken);
+    void saveFcmToken(Long userId, String fcmToken);
 }

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
@@ -5,15 +5,21 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import umc.puppymode.apiPayload.code.status.ErrorStatus;
 import umc.puppymode.apiPayload.exception.GeneralException;
 import umc.puppymode.config.security.JwtTokenProvider;
 import umc.puppymode.config.security.UserAuthentication;
+import umc.puppymode.domain.Token;
 import umc.puppymode.domain.User;
+import umc.puppymode.domain.enums.TokenType;
+import umc.puppymode.repository.TokenRepository;
 import umc.puppymode.repository.UserRepository;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 import umc.puppymode.web.dto.LoginResponseDTO;
 import umc.puppymode.web.dto.UserInfoDTO;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +28,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRepository tokenRepository;
 
     @Override
     public LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo) {
@@ -75,4 +82,39 @@ public class UserAuthServiceImpl implements UserAuthService {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED);
         }
     }
+
+    @Transactional
+    @Override
+    public void saveFcmToken(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Token token = tokenRepository.findByUserAndTokenType(user, TokenType.FCM)
+                .orElseGet(() -> createNewToken(user));
+
+        updateTokenIfChanged(token, fcmToken);
+    }
+
+    private Token createNewToken(User user) {
+        return Token.builder()
+                .user(user)
+                .tokenType(TokenType.FCM)
+                .build();
+    }
+
+    private void updateTokenIfChanged(Token token, String fcmToken) {
+        if (!fcmToken.equals(token.getToken())) {
+            token.setToken(fcmToken);
+            tokenRepository.save(token);
+        }
+    }
+
+    @Override
+    public LoginResponseDTO loginWithFcmToken(LoginResponseDTO loginResponseDTO, String fcmToken) {
+        if (StringUtils.hasText(fcmToken)) {
+            saveFcmToken(loginResponseDTO.getUserInfo().getUserId(), fcmToken);
+        }
+        return loginResponseDTO;
+    }
+
 }

--- a/src/main/java/umc/puppymode/service/UserService/UserQueryService.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserQueryService.java
@@ -1,21 +1,13 @@
 package umc.puppymode.service.UserService;
 
 import umc.puppymode.domain.Puppy;
-import umc.puppymode.domain.User;
 import umc.puppymode.web.dto.UserResponseDTO;
 
-import java.util.List;
 
 public interface UserQueryService {
 
     // 사용자 알림 수신 상태 조회
     UserResponseDTO getUserNotificationStatus(Long userId);
-
-    // 모든 FCM 토큰 조회
-    List<String> getAllFcmTokens();
-
-    // FCM 토큰으로 사용자 조회
-    User getUserByFcmToken(String token);
 
     // 사용자 id로 강아지 정보 조회
     Puppy getUserPuppy(Long userId);

--- a/src/main/java/umc/puppymode/service/UserService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserQueryServiceImpl.java
@@ -1,8 +1,6 @@
 package umc.puppymode.service.UserService;
 
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.puppymode.apiPayload.code.status.ErrorStatus;
@@ -13,7 +11,6 @@ import umc.puppymode.repository.PuppyRepository;
 import umc.puppymode.repository.UserRepository;
 import umc.puppymode.web.dto.UserResponseDTO;
 
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,22 +27,6 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         return new UserResponseDTO(user.getReceiveNotifications());
-    }
-
-    // 모든 FCM 토큰 조회
-    @Override
-    public List<String> getAllFcmTokens() {
-        return userRepository.findAllFcmTokensWithNotification();
-    }
-
-    // FCM 토큰으로 사용자 정보 조회
-    @Override
-    public User getUserByFcmToken(String token) {
-        if (token == null || token.isEmpty()) {
-            throw new GeneralException(ErrorStatus.FIREBASE_MISSING_TOKEN);
-        }
-        return userRepository.findByFcmToken(token)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
     // 사용자 id로 강아지 정보 조회

--- a/src/main/java/umc/puppymode/web/controller/FcmController.java
+++ b/src/main/java/umc/puppymode/web/controller/FcmController.java
@@ -8,7 +8,10 @@ import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.service.FcmService.FcmAppointmentService;
 import umc.puppymode.service.FcmService.FcmPlaytimeService;
 import umc.puppymode.service.FcmService.FcmService;
-import umc.puppymode.web.dto.*;
+import umc.puppymode.web.dto.FCMDTO.FCMAppointmentRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMPlayResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMRequestDTO;
+import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
 
 @Slf4j
 @RestController

--- a/src/main/java/umc/puppymode/web/controller/FcmController.java
+++ b/src/main/java/umc/puppymode/web/controller/FcmController.java
@@ -47,10 +47,9 @@ public class FcmController {
 
     @PostMapping("/appointments")
     @Operation(summary = "술 약속 푸시 알림 API", description = "약속 시간에 맞춰 약속 장소 1km 이내 도달 시 최초 알림을 전송하고, 이후 1시간 간격으로 랜덤 알림을 5회 제공합니다.")
-    public ResponseEntity<ApiResponse<FCMResponseDTO>> sendDrinkingScheduleNotification(
-            @RequestBody FCMAppointmentRequestDTO fcmAppointmentRequestDTO) {
+    public ResponseEntity<ApiResponse<FCMResponseDTO>> sendDrinkingScheduleNotification() {
 
-        ApiResponse<FCMResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications(fcmAppointmentRequestDTO);
+        ApiResponse<FCMResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/FcmController.java
+++ b/src/main/java/umc/puppymode/web/controller/FcmController.java
@@ -43,7 +43,7 @@ public class FcmController {
     }
 
     @PostMapping("/appointments")
-    @Operation(summary = "술 약속 푸시 알림 API", description = "약속 시간에 맞춰 약속 장소 1km 이내 도달 시 최초 알림을 전송하고, 이후 1분 간격으로 랜덤 알림을 5회 제공합니다.")
+    @Operation(summary = "술 약속 푸시 알림 API", description = "진행 중인 약속에 대해 첫 알림을 전송하고 이후 1분 간격으로 랜덤 푸시 알림을 전송합니다.")
     public ResponseEntity<ApiResponse<FCMAppointmentResponseDTO>> sendDrinkingScheduleNotification() {
 
         ApiResponse<FCMAppointmentResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications();

--- a/src/main/java/umc/puppymode/web/controller/FcmController.java
+++ b/src/main/java/umc/puppymode/web/controller/FcmController.java
@@ -46,7 +46,7 @@ public class FcmController {
     }
 
     @PostMapping("/appointments")
-    @Operation(summary = "술 약속 푸시 알림 API", description = "약속 시간에 맞춰 약속 장소 1km 이내 도달 시 최초 알림을 전송하고, 이후 1시간 간격으로 랜덤 알림을 5회 제공합니다.")
+    @Operation(summary = "술 약속 푸시 알림 API", description = "약속 시간에 맞춰 약속 장소 1km 이내 도달 시 최초 알림을 전송하고, 이후 1분 간격으로 랜덤 알림을 5회 제공합니다.")
     public ResponseEntity<ApiResponse<FCMResponseDTO>> sendDrinkingScheduleNotification() {
 
         ApiResponse<FCMResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications();

--- a/src/main/java/umc/puppymode/web/controller/FcmController.java
+++ b/src/main/java/umc/puppymode/web/controller/FcmController.java
@@ -8,10 +8,7 @@ import umc.puppymode.apiPayload.ApiResponse;
 import umc.puppymode.service.FcmService.FcmAppointmentService;
 import umc.puppymode.service.FcmService.FcmPlaytimeService;
 import umc.puppymode.service.FcmService.FcmService;
-import umc.puppymode.web.dto.FCMDTO.FCMAppointmentRequestDTO;
-import umc.puppymode.web.dto.FCMDTO.FCMPlayResponseDTO;
-import umc.puppymode.web.dto.FCMDTO.FCMRequestDTO;
-import umc.puppymode.web.dto.FCMDTO.FCMResponseDTO;
+import umc.puppymode.web.dto.FCMDTO.*;
 
 @Slf4j
 @RestController
@@ -47,9 +44,9 @@ public class FcmController {
 
     @PostMapping("/appointments")
     @Operation(summary = "술 약속 푸시 알림 API", description = "약속 시간에 맞춰 약속 장소 1km 이내 도달 시 최초 알림을 전송하고, 이후 1분 간격으로 랜덤 알림을 5회 제공합니다.")
-    public ResponseEntity<ApiResponse<FCMResponseDTO>> sendDrinkingScheduleNotification() {
+    public ResponseEntity<ApiResponse<FCMAppointmentResponseDTO>> sendDrinkingScheduleNotification() {
 
-        ApiResponse<FCMResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications();
+        ApiResponse<FCMAppointmentResponseDTO> response = fcmAppointmentService.scheduleDrinkingNotifications();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
@@ -29,7 +29,8 @@ public class KakaoLoginController {
             description = "카카오 서버로부터 발급받은 `Access Token`을 사용하여,  \n" +
                     "사용자 정보를 가져온 뒤, 서버에서 JWT를 발급받는 API입니다.  \n" +
                     "로그인 및 회원가입 처리를 포함합니다.")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> callback(@RequestParam("accessToken") String accessToken) {
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> callback(@RequestParam("accessToken") String accessToken,
+                                                                  @RequestParam(value = "FCMToken", required = false) String fcmToken) {
         try {
             // 사용자 정보 가져오기
             KakaoUserInfoResponseDTO userInfo = kakaoService.getUserInfo(accessToken);
@@ -45,6 +46,9 @@ public class KakaoLoginController {
 
             // 로그인 또는 회원가입 처리
             LoginResponseDTO loginResponse = userAuthService.createOrUpdateUser(userInfo);
+
+            // FCM 토큰 저장
+            loginResponse = userAuthService.loginWithFcmToken(loginResponse, fcmToken);
 
             // 성공 응답 반환
             return ResponseEntity.ok(ApiResponse.onSuccess(loginResponse));

--- a/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoLoginController.java
@@ -28,7 +28,8 @@ public class KakaoLoginController {
     @Operation(summary = "카카오 로그인 API",
             description = "카카오 서버로부터 발급받은 `Access Token`을 사용하여,  \n" +
                     "사용자 정보를 가져온 뒤, 서버에서 JWT를 발급받는 API입니다.  \n" +
-                    "로그인 및 회원가입 처리를 포함합니다.")
+                    "로그인 및 회원가입 처리를 포함합니다.\n" +
+                    "`FCMToken`을 함께 전송하여 푸시 알림을 위한 토큰을 저장합니다.")
     public ResponseEntity<ApiResponse<LoginResponseDTO>> callback(@RequestParam("accessToken") String accessToken,
                                                                   @RequestParam(value = "FCMToken", required = false) String fcmToken) {
         try {

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMAppointmentRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMAppointmentRequestDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.FCMDTO;
 
 import lombok.*;
 

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMAppointmentResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMAppointmentResponseDTO.java
@@ -1,0 +1,24 @@
+package umc.puppymode.web.dto.FCMDTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class FCMAppointmentResponseDTO {
+
+    private String message;
+    private List<Long> appointmentIds;
+
+    public FCMAppointmentResponseDTO(String message, Long appointmentId) {
+        this.message = message;
+        this.appointmentIds = List.of(appointmentId);
+    }
+
+    public FCMAppointmentResponseDTO(String message, List<Long> appointmentIds) {
+        this.message = message;
+        this.appointmentIds = appointmentIds;
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMPlayRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMPlayRequestDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.FCMDTO;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMPlayResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMPlayResponseDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.FCMDTO;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMRequestDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.FCMDTO;
 
 import lombok.*;
 

--- a/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/FCMDTO/FCMResponseDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.FCMDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
FCM 토큰 관련 로직 수정 및 개선

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #50 

## ⏳ 작업 내용
- FCM 토큰 저장: 카카오 로그인 시, access token과 함께 Request parameter로 받아 저장합니다.
- 술 약속 푸시 알림
    - 시간과 장소를 기준으로 푸시 알림을 보내는 대신, 술 약속 상태(ONGOING)에 따라 푸시 알림을 전송하도록 변경했습니다.
    - 푸시 알림 전송 로직 비동기로 처리했습니다.
- DB: 기존 user 테이블에서 fcm 토큰을 저장했으나, 토큰 갱신 관리를 위해 별도의 token 테이블 따로 생성했습니다.

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
FCM 토큰 삭제는 로그아웃 구현 후 하겠습니다 😊
