### PR TITLE
[REFACTOR] 술 약속 관련 JWT 수정 #66

### DIFF
--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Repository
 public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingAppointment, Long> {
-    Page<DrinkingAppointment> findByStatus(AppointmentStatus status, Pageable pageable);
 
     @Query("SELECT CASE WHEN COUNT(a) > 0 THEN true ELSE false END " +
             "FROM DrinkingAppointment a " +
@@ -26,4 +25,10 @@ public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingApp
             "JOIN FETCH da.user " +
             "WHERE da.status = :status")
     List<DrinkingAppointment> findByStatusWithUser(@Param("status") AppointmentStatus status);
+
+    // 특정 사용자와 상태에 따라 약속 조회
+    Page<DrinkingAppointment> findByUser_UserIdAndStatus(Long userId, AppointmentStatus status, Pageable pageable);
+
+    // 특정 사용자의 모든 약속 조회
+    Page<DrinkingAppointment> findByUser_UserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
@@ -5,7 +5,7 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
 public interface DrinkingAppointmentCommendService {
     DrinkingAppointmentResponseDTO.AppointmentResultDTO createDrinkingAppointment(DrinkingAppointmentRequestDTO.AppointmentDTO request, Long userId);
-    void deleteDrinkingAppointment(Long appointmentId);
-    void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request);
-    void completeDrinkingAppointment(Long appointmentId);
+    void deleteDrinkingAppointment(Long appointmentId, Long userId);
+    void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId);
+    void completeDrinkingAppointment(Long appointmentId, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
@@ -53,43 +53,75 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
 
     @Override
     @Transactional
-    public void deleteDrinkingAppointment(Long appointmentId) {
+    public void deleteDrinkingAppointment(Long appointmentId, Long userId) {
+
+        // User 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
+
         DrinkingAppointment appointment = repository.findById(appointmentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 약속 소유자 검증
+        if (!appointment.getUser().getUserId().equals(user.getUserId())) {
+            throw new IllegalStateException("해당 약속을 삭제할 권한이 없습니다.");
+        }
 
         repository.delete(appointment);
     }
 
     @Override
     @Transactional
-    public void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request) {
+    public void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId) {
+
+        // User 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
 
         //약속 조회
         DrinkingAppointment appointment = repository.findById(appointmentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 약속 소유자 검증
+        if (!appointment.getUser().getUserId().equals(user.getUserId())) {
+            throw new IllegalStateException("해당 약속을 미룰 권한이 없습니다.");
+        }
 
         // 시간 유효성 검증
         if (request.getDateTime().isBefore(LocalDateTime.now())) {
             throw new IllegalArgumentException("현재 시간 이전으로 설정할 수 없습니다.");
         }
 
+        validateAppointmentStatusForRescheduling(appointment);
+
+        appointment.setDateTime(request.getDateTime());
+    }
+
+    private static void validateAppointmentStatusForRescheduling(DrinkingAppointment appointment) {
         // 술 약속 상태 검증
         if (appointment.getStatus() == AppointmentStatus.ONGOING){
             throw new IllegalArgumentException("이미 진행 중인 약속은 미룰 수 없습니다.");
         } else if (appointment.getStatus() == AppointmentStatus.COMPLETED) {
             throw new IllegalArgumentException("이미 완료 된 약속은 미를 수 없습니다.");
         }
-
-        appointment.setDateTime(request.getDateTime());
     }
 
     @Override
     @Transactional
-    public void completeDrinkingAppointment(Long appointmentId) {
+    public void completeDrinkingAppointment(Long appointmentId, Long userId) {
+
+        // User 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
 
         // 약속 조회
         DrinkingAppointment appointment = repository.findById(appointmentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 약속 소유자 검증
+        if (!appointment.getUser().getUserId().equals(user.getUserId())) {
+            throw new IllegalStateException("음주를 종료할 권한이 없습니다.");
+        }
 
         // 해당 약속 상태가 ONGOING 상태 인지 확인
         AppointmentStatus status = appointment.getStatus();

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
@@ -5,7 +5,7 @@ import umc.puppymode.domain.enums.AppointmentStatus;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
 public interface DrinkingAppointmentQueryService {
-    DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId);
-    DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size);
-    boolean isDrinkingActive(Long appointmentId);
+    DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId, Long userId);
+    DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size, Long userId);
+    boolean isDrinkingActive(Long appointmentId, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/LocationService/LocationService.java
+++ b/src/main/java/umc/puppymode/service/LocationService/LocationService.java
@@ -5,5 +5,5 @@ import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
 public interface LocationService {
-    ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> startAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.StartAppointmentRequestDTO request);
+    ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> startAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.StartAppointmentRequestDTO request, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
@@ -27,10 +27,15 @@ public class LocationServiceImpl implements LocationService {
     private final UrlPathHelper mvcUrlPathHelper;
 
     @Override
-    public ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> startAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.StartAppointmentRequestDTO request) {
+    public ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> startAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.StartAppointmentRequestDTO request, Long userId) {
         // 약속 정보 조회
         DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.APPOINTMENT_NOT_FOUND));
+
+        // 약속 소유자 검증
+        if (!appointment.getUser().getUserId().equals(userId)) {
+            throw new IllegalStateException("해당 약속을 시작할 권한이 없습니다.");
+        }
 
         // 약속 장소 위도/경도
         double targetLatitude = appointment.getLatitude();
@@ -59,7 +64,7 @@ public class LocationServiceImpl implements LocationService {
         drinkingAppointmentRepository.save(appointment);
 
         //음주 상태 조회
-        boolean idDrinking = drinkingAppointmentQueryService.isDrinkingActive(appointmentId);
+        boolean idDrinking = drinkingAppointmentQueryService.isDrinkingActive(appointmentId, userId);
 
         DrinkingAppointmentResponseDTO.StartAppointmentResultDTO response = new DrinkingAppointmentResponseDTO.StartAppointmentResultDTO(
                 appointment.getAppointmentId(),

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -51,9 +51,12 @@ public class DrinkingAppointmentController {
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         // 서비스 호출
         DrinkingAppointmentResponseDTO.AppointmentListResultDTO response =
-                drinkingAppointmentQueryService.getAllDrinkingAppointments(status, page, size);
+                drinkingAppointmentQueryService.getAllDrinkingAppointments(status, page, size, userId);
 
         return ApiResponse.onSuccess(response, "SUCCESS_GET_ALL_APPOINTMENTS", "술 약속 리스트 조회 성공");
     }
@@ -64,9 +67,12 @@ public class DrinkingAppointmentController {
     public ApiResponse<DrinkingAppointmentResponseDTO.AppointmentResultDTO> getAppointmentById(
             @PathVariable Long appointmentId) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         // 서비스 호출
         DrinkingAppointmentResponseDTO.AppointmentResultDTO response =
-                drinkingAppointmentQueryService.getDrinkingAppointmentById(appointmentId);
+                drinkingAppointmentQueryService.getDrinkingAppointmentById(appointmentId, userId);
 
         return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_GET_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_GET_SUCCESS.getMessage());
     }
@@ -75,8 +81,11 @@ public class DrinkingAppointmentController {
     @Operation(summary = "술 약속 및 음주 상태 조회하기  API", description = "술 약속 상태를 조회하며, 술 약속이 'ONGOING'일 때 음주 상태는 true로 반환합니다.:)")
     public ApiResponse<?> getAppointmentStatus(@PathVariable Long appointmentId) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         // 음주 상태 가져오기
-        boolean isDrinking = drinkingAppointmentQueryService.isDrinkingActive(appointmentId);
+        boolean isDrinking = drinkingAppointmentQueryService.isDrinkingActive(appointmentId, userId);
 
         // 업데이트된 상태를 엔티티에서 가져옴
         DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
@@ -90,7 +99,10 @@ public class DrinkingAppointmentController {
     @Operation(summary = "술 약속 삭제 API", description = "술 약속을 삭제하는 API입니다 :)")
     public ApiResponse<Void> deleteAppointment(@PathVariable Long appointmentId) {
 
-        drinkingAppointmentCommendService.deleteDrinkingAppointment(appointmentId);
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
+        drinkingAppointmentCommendService.deleteDrinkingAppointment(appointmentId, userId);
         return ApiResponse.onSuccess(SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_DELETE_SUCCESS.getMessage());
     }
 
@@ -100,8 +112,11 @@ public class DrinkingAppointmentController {
             @PathVariable Long appointmentId,
             @Valid @RequestBody DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         //시간 업데이트
-        drinkingAppointmentCommendService.rescheduleDrinkingAppointment(appointmentId, request);
+        drinkingAppointmentCommendService.rescheduleDrinkingAppointment(appointmentId, request, userId);
 
         // 업데이트된 상태를 엔티티에서 가져옴
         DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
@@ -118,8 +133,11 @@ public class DrinkingAppointmentController {
     public ApiResponse<?> completedAppointmentStatus(
             @PathVariable Long appointmentId) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         // 상태 업데이트
-        drinkingAppointmentCommendService.completeDrinkingAppointment(appointmentId);
+        drinkingAppointmentCommendService.completeDrinkingAppointment(appointmentId, userId);
 
         // 업데이트된 상태를 엔티티에서 가져와서 "COMPLETED"로 전환된 시점에 updated_at 값을 가져오기
         DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
@@ -136,8 +154,11 @@ public class DrinkingAppointmentController {
             @PathVariable Long appointmentId,
             @Valid @RequestBody DrinkingAppointmentRequestDTO.StartAppointmentRequestDTO request) {
 
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
         // 사용자의 현 위치와 약속 위치 및 시간 확인 + 상태 업데이트
-        ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> response = locationService.startAppointment(appointmentId, request);
+        ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> response = locationService.startAppointment(appointmentId, request, userId);
 
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
# 🚀 개요
기존 술약속 관련 JWT 나머지 API에도 적용했습니다.

## 📌 관련 이슈번호
- Closes #66 

## ⏳ 작업 내용
- 술약속 관련 나머지 API JWT 적용

### 📝 논의사항
공용문서에 술약속이 수정, 삭제가 가능하다고 하셨는데, 수정이 지금 술약속 미루기(시간만 미룸)뿐이라, 약속 자체를 수정할 수 있는 API도 추가하겠습니다!
