### PR TITLE
[REFACTOR] 술 약속 미루기 응답 수정 #70

### DIFF
--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
@@ -6,6 +6,6 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 public interface DrinkingAppointmentCommendService {
     DrinkingAppointmentResponseDTO.AppointmentResultDTO createDrinkingAppointment(DrinkingAppointmentRequestDTO.AppointmentDTO request, Long userId);
     void deleteDrinkingAppointment(Long appointmentId, Long userId);
-    void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId);
+    DrinkingAppointmentResponseDTO.RescheduleResultDTO rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId);
     void completeDrinkingAppointment(Long appointmentId, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
@@ -72,7 +72,7 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
 
     @Override
     @Transactional
-    public void rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId) {
+    public DrinkingAppointmentResponseDTO.RescheduleResultDTO rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId) {
 
         // User 엔티티 조회
         User user = userRepository.findById(userId)
@@ -87,14 +87,27 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
             throw new IllegalStateException("해당 약속을 미룰 권한이 없습니다.");
         }
 
-        // 시간 유효성 검증
-        if (request.getDateTime().isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("현재 시간 이전으로 설정할 수 없습니다.");
+        // 시간 유효성 검증 및 기본값 복귀
+        LocalDateTime selectedTime = request.getDateTime();
+        boolean isDefaultApplied = false;
+
+        if (selectedTime.isBefore(LocalDateTime.now()) || selectedTime.isBefore(appointment.getDateTime())) {
+            // 기본값 복구
+            selectedTime = appointment.getDateTime();
+            isDefaultApplied = true;
         }
 
+        // 술약속 상태가 SCHEDULED인지 검증
         validateAppointmentStatusForRescheduling(appointment);
 
-        appointment.setDateTime(request.getDateTime());
+        // 수정된 시간으로 약속 업데이트
+        appointment.setDateTime(selectedTime);
+
+        return new DrinkingAppointmentResponseDTO.RescheduleResultDTO(
+                appointment.getAppointmentId(),
+                selectedTime,
+                isDefaultApplied ? "기본값으로 복구되었습니다." : "요청하신 시간으로 성공적으로 변경되었습니다."
+        );
     }
 
     private static void validateAppointmentStatusForRescheduling(DrinkingAppointment appointment) {

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -116,16 +116,9 @@ public class DrinkingAppointmentController {
         Long userId = userAuthService.getCurrentUserId();
 
         //시간 업데이트
-        drinkingAppointmentCommendService.rescheduleDrinkingAppointment(appointmentId, request, userId);
+        DrinkingAppointmentResponseDTO.RescheduleResultDTO response = drinkingAppointmentCommendService.rescheduleDrinkingAppointment(appointmentId, request, userId);
 
-        // 업데이트된 상태를 엔티티에서 가져옴
-        DrinkingAppointment appointment = drinkingAppointmentRepository.findById(appointmentId)
-                .orElseThrow(() -> new IllegalStateException("업데이트 후 약속을 찾을 수 없습니다."));
-
-        DrinkingAppointmentResponseDTO.RescheduleResultDTO response = new DrinkingAppointmentResponseDTO.RescheduleResultDTO(appointmentId, appointment.getDateTime());
-
-        return ApiResponse.onSuccess(SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getMessage());
-
+        return ApiResponse.onSuccess(response, SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getCode(), SuccessStatus.APPOINTMENT_RESCHEDULED_PATCH_SUCCESS.getMessage());
     }
 
     @PatchMapping("/{appointmentId}/status")

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
@@ -55,6 +55,7 @@ public class DrinkingAppointmentResponseDTO {
     public static class RescheduleResultDTO {
         private Long appointmentId;
         private LocalDateTime rescheduledTime;
+        private String message;
     }
 
     @Getter


### PR DESCRIPTION
# 🚀 개요
술약속 미루기 응답을 기존에는 기준에 어긋날 시 모두 에러로 반환했는데, 백에서 유효성 검증 및 기본값 설정 처리 후 모두 성공응답으로 반환하여 프론트에서의 에러처리를 줄이도록 코드 수정했습니다. 

## 📌 관련 이슈번호
- Closes #70 

## ⏳ 작업 내용
- 술 약속 미루기 응답 수정

### 📝 논의사항
에러핸들링을 프론트에서 다시 처리해야할 수 있을 것 같아서 백에서 처리 후 모두 성공 응답으로 변경하긴 했으나, 만약에 그냥 에러로 반환하는게 낫다고 하시면,, 기존 코드로 수정해도 괜찮습니다..
