### PR TITLE
[FEAT] 술 약속 수정하기 API 구현 및 예외처리 #73

### DIFF
--- a/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
+++ b/src/main/java/umc/puppymode/converter/DrinkingAppointmentConverter.java
@@ -38,4 +38,14 @@ public class DrinkingAppointmentConverter {
                 .status(entity.getStatus().name().toLowerCase()) //일단 API 명세에는 소문자로 되어있어서 소문자 처리.
                 .build();
     }
+
+    public static DrinkingAppointmentResponseDTO.UpdateAppointmentResultDTO toUpdateAppointmentDTO(DrinkingAppointment appointment) {
+        return DrinkingAppointmentResponseDTO.UpdateAppointmentResultDTO.builder()
+                .appointmentId(appointment.getAppointmentId())
+                .updatedTime(appointment.getDateTime())
+                .address(appointment.getAddress())
+                .locationName(appointment.getLocationName())
+                .appointmentStatus(appointment.getStatus())
+                .build();
+    }
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendService.java
@@ -8,4 +8,5 @@ public interface DrinkingAppointmentCommendService {
     void deleteDrinkingAppointment(Long appointmentId, Long userId);
     DrinkingAppointmentResponseDTO.RescheduleResultDTO rescheduleDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.RescheduleAppointmentRequestDTO request, Long userId);
     void completeDrinkingAppointment(Long appointmentId, Long userId);
+    DrinkingAppointmentResponseDTO.UpdateAppointmentResultDTO updateDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.UpdateAppointmentDTO request, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentCommendServiceImpl.java
@@ -14,6 +14,7 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -31,15 +32,8 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
 
-        // 사용자가 요청한 날짜 확인
-        LocalDate appointmentDate = request.getDateTime().toLocalDate();
-
-        // 해당 날짜에 이미 약속이 있는지 확인
-        boolean alreadyExists = repository.existsByUserAndDate(user, appointmentDate);
-
-        if (alreadyExists) {
-            throw new IllegalStateException(appointmentDate + "에 이미 약속이 생성되었습니다.");
-        }
+        // 시간 유효성 검증
+        validateAppointmentDateTime(request.getDateTime(), user);
 
         // DTO → Entity 변환
         DrinkingAppointment entity = DrinkingAppointmentConverter.toEntity(request);
@@ -66,6 +60,9 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
         if (!appointment.getUser().getUserId().equals(user.getUserId())) {
             throw new IllegalStateException("해당 약속을 삭제할 권한이 없습니다.");
         }
+
+        // 상태 검증
+        validateAppointmentStatus(appointment);
 
         repository.delete(appointment);
     }
@@ -98,7 +95,7 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
         }
 
         // 술약속 상태가 SCHEDULED인지 검증
-        validateAppointmentStatusForRescheduling(appointment);
+        validateAppointmentStatus(appointment);
 
         // 수정된 시간으로 약속 업데이트
         appointment.setDateTime(selectedTime);
@@ -108,15 +105,6 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
                 selectedTime,
                 isDefaultApplied ? "기본값으로 복구되었습니다." : "요청하신 시간으로 성공적으로 변경되었습니다."
         );
-    }
-
-    private static void validateAppointmentStatusForRescheduling(DrinkingAppointment appointment) {
-        // 술 약속 상태 검증
-        if (appointment.getStatus() == AppointmentStatus.ONGOING){
-            throw new IllegalArgumentException("이미 진행 중인 약속은 미룰 수 없습니다.");
-        } else if (appointment.getStatus() == AppointmentStatus.COMPLETED) {
-            throw new IllegalArgumentException("이미 완료 된 약속은 미를 수 없습니다.");
-        }
     }
 
     @Override
@@ -143,4 +131,68 @@ public class DrinkingAppointmentCommendServiceImpl implements DrinkingAppointmen
         }
         else throw new IllegalArgumentException("현재 진행 중인 약속이 아닙니다.");
     }
+
+    @Override
+    public DrinkingAppointmentResponseDTO.UpdateAppointmentResultDTO updateDrinkingAppointment(Long appointmentId, DrinkingAppointmentRequestDTO.UpdateAppointmentDTO request, Long userId) {
+        // User 엔티티 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자 ID 입니다."));
+
+        // 기존 약속 조회
+        DrinkingAppointment appointment = repository.findById(appointmentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 약속을 찾을 수 없습니다."));
+
+        // 약속 소유자 검증
+        if (!appointment.getUser().getUserId().equals(user.getUserId())) {
+            throw new IllegalStateException("해당 약속을 수정할 권한이 없습니다.");
+        }
+
+        // 술약속 상태가 SCHEDULED 인지 검증
+        validateAppointmentStatus(appointment);
+
+        if(request.getDateTime() != null) {
+            // 요청 시간이 현재 시간 이전일 경우 예외 처리
+            if (request.getDateTime().isBefore(LocalDateTime.now())) {
+                throw new IllegalStateException("현재 시간 이전으로 약속을 설정할 수 없습니다.");
+            }
+        }
+
+        // 요청 데이터 수정
+        Optional.ofNullable(request.getDateTime()).ifPresent(appointment::setDateTime);
+        Optional.ofNullable(request.getLatitude()).ifPresent(appointment::setLatitude);
+        Optional.ofNullable(request.getLongitude()).ifPresent(appointment::setLongitude);
+        Optional.ofNullable(request.getAddress()).ifPresent(appointment::setAddress);
+        Optional.ofNullable(request.getLocationName()).ifPresent(appointment::setLocationName);
+
+        // 수정된 엔티티 저장
+        DrinkingAppointment updatedEntity = repository.save(appointment);
+
+        // Entity → DTO 변환
+        return DrinkingAppointmentConverter.toUpdateAppointmentDTO(updatedEntity);
+    }
+
+    private static void validateAppointmentStatus(DrinkingAppointment appointment) {
+        // 술 약속 상태 검증
+        if (appointment.getStatus() == AppointmentStatus.ONGOING){
+            throw new IllegalArgumentException("이미 진행 중인 약속은 수정할 수 없습니다.");
+        } else if (appointment.getStatus() == AppointmentStatus.COMPLETED) {
+            throw new IllegalArgumentException("이미 완료 된 약속은 수정할 수 없습니다.");
+        }
+    }
+
+    private void validateAppointmentDateTime(LocalDateTime dateTime, User user) {
+        // 요청 시간이 현재 시간 이전일 경우 예외 처리
+        if (dateTime.isBefore(LocalDateTime.now())) {
+            throw new IllegalStateException("현재 시간 이전으로 약속을 설정할 수 없습니다.");
+        }
+
+        // 사용자가 요청한 날짜 확인
+        LocalDate appointmentDate = dateTime.toLocalDate();
+        // 해당 날짜에 이미 약속이 있는지 확인
+        boolean alreadyExists = repository.existsByUserAndDate(user, appointmentDate);
+        if (alreadyExists) {
+            throw new IllegalStateException(appointmentDate + "에 이미 약속이 생성되었습니다.");
+        }
+    }
+
 }

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -141,7 +141,7 @@ public class DrinkingAppointmentController {
         return ApiResponse.onSuccess(response, "SUCCESS_END_DRINKING_APPOINTMENT", "음주 상태 종료 성공");
     }
 
-    @PatchMapping("/{appointmentId}")
+    @PatchMapping("/{appointmentId}/start")
     @Operation(summary = "술 약속 시작하기 API", description = "사용자 현재 위치에 기반해 시간 + 장소가 범위 내에 들어오면 술 약속을 시작합니다.")
     public ResponseEntity<ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO>> startAppointment(
             @PathVariable Long appointmentId,
@@ -154,6 +154,22 @@ public class DrinkingAppointmentController {
         ApiResponse<DrinkingAppointmentResponseDTO.StartAppointmentResultDTO> response = locationService.startAppointment(appointmentId, request, userId);
 
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{appointmentId}")
+    @Operation(summary = "술 약속 수정하기 API", description = "기존에 설정된 술 약속을 수정합니다.(술약속 상태가 진행중, 완료일 시 불가)")
+    public ApiResponse<?> updateAppointment(
+            @PathVariable Long appointmentId,
+            @Valid @RequestBody DrinkingAppointmentRequestDTO.UpdateAppointmentDTO request) {
+
+        //userId
+        Long userId = userAuthService.getCurrentUserId();
+
+        //상태 업데이트
+        DrinkingAppointmentResponseDTO.UpdateAppointmentResultDTO response = drinkingAppointmentCommendService.updateDrinkingAppointment(appointmentId, request, userId);
+
+        return ApiResponse.onSuccess(response, "APPOINTMENT_UPDATE_SUCCESS", "술 약속 수정 성공");
+
     }
 
 }

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentRequestDTO.java
@@ -55,6 +55,26 @@ public class DrinkingAppointmentRequestDTO {
         @Max(value = 180, message = "경도 값은 180 이하여야 합니다.")
         private Double longitude;
     }
+
+    @Getter
+    public static class UpdateAppointmentDTO {
+        //날짜가 오늘로 고정인지, 아니면 변동 가능한 지에 따라 추후 수정가능성 있습니다.
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        private LocalDateTime dateTime;
+
+        @Min(value = -90, message = "위도 값은 -90 이상이어야 합니다.")
+        @Max(value = 90, message = "위도 값은 90 이하여야 합니다.")
+        private Double latitude;
+
+        @Min(value = -180, message = "경도 값은 -180 이상이어야 합니다.")
+        @Max(value = 180, message = "경도 값은 180 이하여야 합니다.")
+        private Double longitude;
+
+        private String address;
+
+        @Size(max = 255, message = "장소 이름은 255자 이하여야 합니다.")
+        private String locationName;
+    }
 }
 
 

--- a/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/DrinkingAppointmentResponseDTO.java
@@ -81,4 +81,15 @@ public class DrinkingAppointmentResponseDTO {
 
         private LocalDateTime startTime;
     }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateAppointmentResultDTO {
+        private Long appointmentId;
+        private LocalDateTime updatedTime;
+        private String address;
+        private String locationName;
+        private AppointmentStatus appointmentStatus;
+    }
 }


### PR DESCRIPTION
# 🚀 개요
술 약속 수정하기 API 구현했습니다.
술 약속 생성, 삭제 관련 시간 및 상태에 대한 예외처리도 수정했습니다.

## 📌 관련 이슈번호
- Closes #73 

## ⏳ 작업 내용
- 술약속 수정하기 API 구현
- 술약속 생성, 삭제 관련 예외처리 수정
