### PR TITLE
Feat/#49 user management

### DIFF
--- a/src/main/java/umc/puppymode/domain/User.java
+++ b/src/main/java/umc/puppymode/domain/User.java
@@ -22,9 +22,14 @@ public class User extends BaseEntity {
     private String password;
     private Integer points;
     private Boolean receiveNotifications;
+    private Boolean isDeleted;
 
     public void updatePoints(Integer points) {
         this.points += points;
+    }
+
+    public void deactivate() {
+        this.isDeleted = true;
     }
 }
 

--- a/src/main/java/umc/puppymode/repository/UserRepository.java
+++ b/src/main/java/umc/puppymode/repository/UserRepository.java
@@ -4,10 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.puppymode.domain.User;
 import java.util.Optional;
-import java.util.List;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-  
+
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByUserIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
@@ -17,6 +17,8 @@ import umc.puppymode.repository.TokenRepository;
 import umc.puppymode.repository.UserRepository;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 import umc.puppymode.web.dto.LoginResponseDTO;
+
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
@@ -28,21 +30,32 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenRepository tokenRepository;
 
+    @Transactional
     @Override
     public LoginResponseDTO createOrUpdateUser(KakaoUserInfoResponseDTO userInfo) {
         AtomicBoolean isNewUser = new AtomicBoolean(false);
-        User user = userRepository.findByEmail(userInfo.getKakaoAccount().getEmail())
-                .orElseGet(() -> {
-                    isNewUser.set(true);
-                    User newUser = User.builder()
-                            .email(userInfo.getKakaoAccount().getEmail())
-                            .username(userInfo.getKakaoAccount().getProfile().getNickName())
-                            .points(0)
-                            .receiveNotifications(false)
-                            .isDeleted(false)
-                            .build();
-                    return userRepository.save(newUser);
-                });
+
+        Optional<User> optionalUser = userRepository.findByEmail(userInfo.getKakaoAccount().getEmail());
+
+        User user = optionalUser.map(existingUser -> {
+            if (existingUser.getIsDeleted()) {
+                // 탈퇴한 사용자 복구
+                existingUser.setIsDeleted(false);
+                return userRepository.save(existingUser);
+            }
+            return existingUser;
+        }).orElseGet(() -> {
+            // 새 사용자 생성
+            isNewUser.set(true);
+            User newUser = User.builder()
+                    .email(userInfo.getKakaoAccount().getEmail())
+                    .username(userInfo.getKakaoAccount().getProfile().getNickName())
+                    .points(0)
+                    .receiveNotifications(false)
+                    .isDeleted(false)
+                    .build();
+            return userRepository.save(newUser);
+        });
 
         // 현재 사용자 인증 객체 생성
         Authentication authentication = new UserAuthentication(user.getUserId().toString(), null, null);

--- a/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserAuthServiceImpl.java
@@ -39,6 +39,7 @@ public class UserAuthServiceImpl implements UserAuthService {
                             .username(userInfo.getKakaoAccount().getProfile().getNickName())
                             .points(0)
                             .receiveNotifications(false)
+                            .isDeleted(false)
                             .build();
                     return userRepository.save(newUser);
                 });

--- a/src/main/java/umc/puppymode/service/UserService/UserInfoServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserInfoServiceImpl.java
@@ -20,7 +20,7 @@ public class UserInfoServiceImpl implements UserInfoService {
     @Override
     public UserInfoResponseDTO getUserInfo(Long userId) {
         // 사용자 정보 조회
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByUserIdAndIsDeletedFalse(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         // 강아지 정보 조회

--- a/src/main/java/umc/puppymode/service/UserService/UserWithdrawService.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserWithdrawService.java
@@ -1,0 +1,7 @@
+package umc.puppymode.service.UserService;
+
+public interface UserWithdrawService {
+
+    // 회원탈퇴
+    void withdraw(Long userId);
+}

--- a/src/main/java/umc/puppymode/service/UserService/UserWithdrawServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserWithdrawServiceImpl.java
@@ -1,0 +1,24 @@
+package umc.puppymode.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.domain.User;
+import umc.puppymode.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserWithdrawServiceImpl implements UserWithdrawService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.findByUserIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없거나 이미 탈퇴한 상태입니다."));
+
+        user.deactivate();
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/controller/UserWithdrawController.java
+++ b/src/main/java/umc/puppymode/web/controller/UserWithdrawController.java
@@ -1,0 +1,38 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.UserService.UserAuthService;
+import umc.puppymode.service.UserService.UserWithdrawService;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class UserWithdrawController {
+
+    private final UserWithdrawService userWithdrawService;
+    private final UserAuthService userAuthService;
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴 API", description = "회원을 탈퇴하는 API입니다.")
+    public ResponseEntity<?> withdraw(
+            @Parameter(description = "카카오 Access Token")
+            @RequestParam(required = false) Optional<String> accessToken
+    ) {
+
+        Long userId = userAuthService.getCurrentUserId();
+
+        userWithdrawService.withdraw(userId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess("USER_WITHDRAW_SUCCESS", "회원 탈퇴 성공", null));
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
회원 탈퇴 API 추가
소프트 삭제 방식 사용

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #49

## ⏳ 작업 내용

- `UserWithdrawServiceImpl`
    - user의 `is_deleted`를 `true`로 변경함.
 
- `UserWithdrawController`
    -  추후 카카오 로그아웃 구현을 위해 `accessToken`을 받도록 구현함.
    
- `UserAuthServiceImpl` 
    - 로그인 시 `is_deleted`가 `true` 인 경우 계정을 복구함.

- `UserRepository`
    - 탈퇴한 사용자를 제외하고 조회하는 `findByUserIdAndIsDeletedFalse` 메서드 생성함.

### 📝 논의사항
- 우선 로그아웃은 프론트에서 jwt 삭제하는 방식으로 구현.
- 추후 refresh token 구현 시 로그아웃 구현 예정임.