### PR TITLE
[FEAT] 아이템 착용 해제 API 구현 #83

### DIFF
--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
@@ -7,4 +7,5 @@ public interface PuppyItemService {
     Map<String, Object> getItemsByCategory(Long categoryId, Long userId);
     Map<String, Object> purchaseItem(Long categoryId, Long itemId, Long userId);
     Map<String, Object> equipItem(Long categoryId, Long itemId, Long userId);
+    Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -196,4 +196,43 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         return result;
     }
 
+    @Override
+    public Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId) {
+        // 유저 찾기
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+        // 유저의 강아지 찾기
+        Puppy puppy = puppyRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 아이템 찾기
+        PuppyItem item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템이 존재하지 않습니다."));
+
+        // 카테고리 검증
+        if (!item.getCategory().getCategoryId().equals(categoryId)) {
+            throw new IllegalArgumentException("아이템이 해당 카테고리에 속하지 않습니다.");
+        }
+        PuppyItemCategory puppyItemCategory = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리가 존재하지 않습니다."));
+
+        // 아이템 구매 여부 확인
+        PuppyCustomization customization = puppyCustomizationRepository.findByPuppyAndPuppyItem(puppy, item)
+                .orElseThrow(() -> new IllegalArgumentException("구매하지 않은 아이템입니다."));
+
+        // 아이템 착용 여부 확인
+        if (customization.getIsEquipped()) {
+            customization.setIsEquipped(false);
+            puppyCustomizationRepository.save(customization);
+        } else {
+            throw new IllegalArgumentException("이미 착용하지 않은 아이템입니다.");
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("unequippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
+
+        return result;
+    }
+
 }

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -67,5 +67,15 @@ public class PuppyItemController {
         return new ApiResponse<>(true, "SUCCESS_EQUIP_PUPPY_ITEM", "아이템 착용 성공", result);
     }
 
+    @Operation(summary = "아이템 착용 해제 API", description = "강아지가 착용한 아이템을 해제하는 API")
+    @PatchMapping("/{categoryId}/items/{itemId}/unequip")
+    public ResponseEntity<?> unequipItem(@PathVariable Long categoryId,
+                                         @PathVariable Long itemId) {
+        Long userId = userAuthService.getCurrentUserId();
+
+        Map<String, Object> result = puppyItemService.unequipItem(categoryId, itemId, userId);
+        return ResponseEntity.ok(new ApiResponse<>(true, "SUCCESS_UNEQUIP_PUPPY_ITEM", "아이템 착용 해제 성공", result));
+    }
+
 
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
강아지가 착용한 아이템을 해제하는 API를 추가 구현하였습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #83

## ⏳ 작업 내용
- 아이템 착용 해제 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
