### PR TITLE
[FEAT] 음주 달력 관련 API 구현 #74

### DIFF
--- a/src/main/java/umc/puppymode/domain/DrinkHistory.java
+++ b/src/main/java/umc/puppymode/domain/DrinkHistory.java
@@ -20,6 +20,9 @@ public class DrinkHistory extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @OneToOne(mappedBy = "drinkHistory", fetch = FetchType.LAZY)
+    private Feed feed;
+
     @ManyToMany
     @JoinTable(
             name = "drink_history_hangover",

--- a/src/main/java/umc/puppymode/repository/DrinkHistoryItemRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkHistoryItemRepository.java
@@ -1,7 +1,19 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import umc.puppymode.domain.DrinkHistoryItem;
+import umc.puppymode.web.dto.CalenderDTO.CalenderResponseDTO;
+import umc.puppymode.web.dto.CalenderDTO.DrinkHistoryItemDTO;
 
+import java.util.List;
+
+@Repository
 public interface DrinkHistoryItemRepository extends JpaRepository<DrinkHistoryItem, Long> {
+    @Query("SELECT new umc.puppymode.web.dto.CalenderDTO.DrinkHistoryItemDTO(hi.item.itemName, hi.unit, hi.value, hi.safetyValue, hi.maxValue) " +
+            "FROM DrinkHistoryItem hi WHERE hi.history.drinkHistoryId = :drinkHistoryId")
+    List<DrinkHistoryItemDTO> findDrinkItemsByHistoryId(@Param("drinkHistoryId") Long drinkHistoryId);
+
 }

--- a/src/main/java/umc/puppymode/repository/DrinkHistoryRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkHistoryRepository.java
@@ -1,7 +1,26 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import umc.puppymode.domain.DrinkHistory;
+import umc.puppymode.web.dto.CalenderDTO.CalenderListResponseDTO;
 
+import java.util.List;
+
+@Repository
 public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
+    @Query("SELECT new umc.puppymode.web.dto.CalenderDTO.CalenderListResponseDTO(dh.drinkHistoryId, dh.drinkDate) " +
+            "FROM DrinkHistory dh " +
+            "WHERE dh.user.userId = :userId " +
+            "AND FUNCTION('DATE_FORMAT', dh.drinkDate, '%Y-%m') = :month")
+    List<CalenderListResponseDTO> findDrinkDatesByUserAndMonth(@Param("userId") Long userId, @Param("month") String month);
+
+    @Query("SELECT dh FROM DrinkHistory dh " +
+            "LEFT JOIN FETCH dh.hangovers " +
+            "LEFT JOIN FETCH dh.feed " +
+            "WHERE dh.drinkHistoryId = :drinkHistoryId AND dh.user.userId = :userId")
+    DrinkHistory findDrinkHistoryDetail(@Param("userId") Long userId, @Param("drinkHistoryId") Long drinkHistoryId);
+
 }

--- a/src/main/java/umc/puppymode/repository/FeedRepository.java
+++ b/src/main/java/umc/puppymode/repository/FeedRepository.java
@@ -1,7 +1,14 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.puppymode.domain.Feed;
+import umc.puppymode.web.dto.CalenderDTO.FeedDTO;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+    @Query("SELECT new umc.puppymode.web.dto.CalenderDTO.FeedDTO(f.feedingType, f.feedImageUrl) " +
+            "FROM Feed f WHERE f.drinkHistory.drinkHistoryId = :drinkHistoryId")
+    FeedDTO findFeedByHistoryId(@Param("drinkHistoryId") Long drinkHistoryId);
+
 }

--- a/src/main/java/umc/puppymode/service/CalenderService/CalenderQueryService.java
+++ b/src/main/java/umc/puppymode/service/CalenderService/CalenderQueryService.java
@@ -1,0 +1,11 @@
+package umc.puppymode.service.CalenderService;
+
+import umc.puppymode.web.dto.CalenderDTO.CalenderListResponseDTO;
+import umc.puppymode.web.dto.CalenderDTO.CalenderResponseDTO.*;
+
+import java.util.List;
+
+public interface CalenderQueryService {
+    List<CalenderListResponseDTO> getCalender(Long userId, String month);
+    List<CalenderDetailDTO> getCalenderDetail(Long userId, Long drinkHistoryId);
+}

--- a/src/main/java/umc/puppymode/service/CalenderService/CalenderQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/CalenderService/CalenderQueryServiceImpl.java
@@ -1,0 +1,54 @@
+package umc.puppymode.service.CalenderService;
+
+import org.springframework.stereotype.Service;
+import umc.puppymode.domain.DrinkHistory;
+import umc.puppymode.repository.DrinkHistoryItemRepository;
+import umc.puppymode.repository.DrinkHistoryRepository;
+import umc.puppymode.repository.FeedRepository;
+import umc.puppymode.web.dto.CalenderDTO.CalenderListResponseDTO;
+import umc.puppymode.web.dto.CalenderDTO.CalenderResponseDTO.*;
+import umc.puppymode.web.dto.CalenderDTO.DrinkHistoryItemDTO;
+import umc.puppymode.web.dto.CalenderDTO.FeedDTO;
+
+import java.util.List;
+
+@Service
+public class CalenderQueryServiceImpl implements CalenderQueryService{
+    private final DrinkHistoryRepository drinkHistoryRepository;
+    private final DrinkHistoryItemRepository drinkHistoryItemRepository;
+    private final FeedRepository feedRepository;
+
+    public CalenderQueryServiceImpl(DrinkHistoryRepository drinkHistoryRepository,
+                                    DrinkHistoryItemRepository drinkHistoryItemRepository,
+                                    FeedRepository feedRepository) {
+        this.drinkHistoryRepository = drinkHistoryRepository;
+        this.drinkHistoryItemRepository = drinkHistoryItemRepository;
+        this.feedRepository = feedRepository;
+    }
+
+
+    @Override
+    public List<CalenderListResponseDTO> getCalender(Long userId, String month) {
+        return drinkHistoryRepository.findDrinkDatesByUserAndMonth(userId, month);
+    }
+
+    @Override
+    public List<CalenderDetailDTO> getCalenderDetail(Long userId, Long drinkHistoryId) {
+        DrinkHistory drinkHistory = drinkHistoryRepository.findDrinkHistoryDetail(userId, drinkHistoryId);
+        if (drinkHistory == null) {
+            throw new IllegalArgumentException("해당 기록을 찾을 수 없습니다.");
+        }
+
+        List<DrinkHistoryItemDTO> drinkItems = drinkHistoryItemRepository.findDrinkItemsByHistoryId(drinkHistoryId);
+        FeedDTO feed = feedRepository.findFeedByHistoryId(drinkHistoryId);
+
+        return List.of(
+                CalenderDetailDTO.builder()
+                        .drinkHistoryId(drinkHistory.getDrinkHistoryId())
+                        .drinkDate(drinkHistory.getDrinkDate().toString())
+                        .drinkAmount(drinkHistory.getDrinkAmount())
+                        .drinkItems(drinkItems)
+                        .feed(feed)
+                        .build()
+        );
+    }}

--- a/src/main/java/umc/puppymode/web/controller/CalenderController.java
+++ b/src/main/java/umc/puppymode/web/controller/CalenderController.java
@@ -1,0 +1,37 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.service.CalenderService.CalenderQueryService;
+import umc.puppymode.service.UserService.UserAuthService;
+import umc.puppymode.web.dto.CalenderDTO.CalenderListResponseDTO;
+import umc.puppymode.web.dto.CalenderDTO.CalenderResponseDTO.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/calender")
+public class CalenderController {
+    private final CalenderQueryService calenderQueryService;
+    private final UserAuthService userAuthService;
+
+    @GetMapping
+    @Operation(summary = "캘린더 조회 API", description = "캘린더를 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<List<CalenderListResponseDTO>>> getCalender(@RequestParam String month) {
+        Long userId = userAuthService.getCurrentUserId();
+        List<CalenderListResponseDTO> responseDTO = calenderQueryService.getCalender(userId, month);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
+
+    @GetMapping("/daily")
+    @Operation(summary = "캘린더 상세 조회 API", description = "캘린더 상세를 조회하는 API입니다.")
+    public ResponseEntity<ApiResponse<List<CalenderDetailDTO>>> getCalenderDetail(@RequestParam Long drinkHistoryId) {
+        Long userId = userAuthService.getCurrentUserId();
+        List<CalenderDetailDTO> responseDTO = calenderQueryService.getCalenderDetail(userId, drinkHistoryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/CalenderDTO/CalenderListResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/CalenderDTO/CalenderListResponseDTO.java
@@ -1,0 +1,20 @@
+package umc.puppymode.web.dto.CalenderDTO;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+public class CalenderListResponseDTO {
+    private Long drinkHistoryId;
+    private LocalDate drinkDate;
+
+    // 명시적인 생성자 추가 (JPQL에서 사용할 수 있도록)
+    public CalenderListResponseDTO(Long drinkHistoryId, LocalDate drinkDate) {
+        this.drinkHistoryId = drinkHistoryId;
+        this.drinkDate = drinkDate;
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/CalenderDTO/CalenderResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/CalenderDTO/CalenderResponseDTO.java
@@ -1,0 +1,24 @@
+package umc.puppymode.web.dto.CalenderDTO;
+
+import lombok.*;
+
+import java.util.List;
+
+
+public class CalenderResponseDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CalenderDetailDTO {
+        private Long drinkHistoryId;
+        private String drinkDate;
+        private Float drinkAmount;
+
+        private List<DrinkHistoryItemDTO> drinkItems;
+        private FeedDTO feed;
+    }
+
+}

--- a/src/main/java/umc/puppymode/web/dto/CalenderDTO/DrinkHistoryItemDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/CalenderDTO/DrinkHistoryItemDTO.java
@@ -1,0 +1,23 @@
+package umc.puppymode.web.dto.CalenderDTO;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+public class DrinkHistoryItemDTO {
+    private String itemName;
+    private String unit;
+    private Float value;
+    private Float safetyValue;
+    private Float maxValue;
+
+    public DrinkHistoryItemDTO(String itemName, String unit, Float value, Float safetyValue, Float maxValue){
+        this.itemName = itemName;
+        this.unit = unit;
+        this.value = value;
+        this.safetyValue = safetyValue;
+        this.maxValue = maxValue;
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/CalenderDTO/FeedDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/CalenderDTO/FeedDTO.java
@@ -1,0 +1,17 @@
+package umc.puppymode.web.dto.CalenderDTO;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+public class FeedDTO {
+    private String feedingType;
+    private String feedImageUrl;
+
+    public FeedDTO(String feedingType, String feedImageUrl){
+        this.feedingType = feedingType;
+        this.feedImageUrl = feedImageUrl;
+    }
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
음주 달력 관련 API 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #74

## ⏳ 작업 내용
- 음주 달력 조회
- 음주 달력 상세 조회

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
