### PR TITLE
[FEAT] 애니메이션 프레임 조회 API 구현 #39

### DIFF
--- a/src/main/java/umc/puppymode/domain/PuppyAnimation.java
+++ b/src/main/java/umc/puppymode/domain/PuppyAnimation.java
@@ -1,0 +1,33 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.domain.enums.PuppyType;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "puppy_animation")
+public class PuppyAnimation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long animationId;
+
+    @Enumerated(EnumType.STRING)
+    private AnimationType animationType; // 애니메이션 종류
+
+    @Enumerated(EnumType.STRING)
+    private PuppyType puppyType; // 강아지 타입
+
+    private String levelName; // 강아지 레벨 이름
+
+    @OneToMany(mappedBy = "animation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PuppyAnimationImage> animationImages; // 애니메이션 이미지 리스트
+}

--- a/src/main/java/umc/puppymode/domain/PuppyAnimationImage.java
+++ b/src/main/java/umc/puppymode/domain/PuppyAnimationImage.java
@@ -1,0 +1,26 @@
+package umc.puppymode.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "puppy_animation_image")
+public class PuppyAnimationImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "animation_id")
+    private PuppyAnimation animation; // 연결된 애니메이션
+
+    private int frameOrder; // 프레임 순서
+
+    private String imageUrl; // 애니메이션 이미지 URL
+}

--- a/src/main/java/umc/puppymode/domain/enums/AnimationType.java
+++ b/src/main/java/umc/puppymode/domain/enums/AnimationType.java
@@ -1,0 +1,5 @@
+package umc.puppymode.domain.enums;
+
+public enum AnimationType {
+    PLAYING // 놀아주기
+}

--- a/src/main/java/umc/puppymode/repository/PuppyAnimationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyAnimationRepository.java
@@ -1,0 +1,12 @@
+package umc.puppymode.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.puppymode.domain.PuppyAnimation;
+import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.domain.enums.PuppyType;
+
+import java.util.Optional;
+
+public interface PuppyAnimationRepository extends JpaRepository<PuppyAnimation, Long> {
+    Optional<PuppyAnimation> findByAnimationTypeAndPuppyTypeAndLevelName(AnimationType animationType, PuppyType puppyType, String levelName);
+}

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationService.java
@@ -1,0 +1,8 @@
+package umc.puppymode.service.PuppyService;
+
+import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.web.dto.AnimationFramesResponseDTO;
+
+public interface PuppyAnimationService {
+    AnimationFramesResponseDTO getAnimaitonFrames(AnimationType animationType, Long userId);
+}

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationServiceImpl.java
@@ -1,0 +1,51 @@
+package umc.puppymode.service.PuppyService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyAnimation;
+import umc.puppymode.domain.PuppyAnimationImage;
+import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.repository.PuppyAnimationRepository;
+import umc.puppymode.repository.PuppyRepository;
+import umc.puppymode.web.dto.AnimationFramesResponseDTO;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PuppyAnimationServiceImpl implements PuppyAnimationService{
+
+    private final PuppyAnimationRepository puppyAnimationRepository;
+    private final PuppyRepository puppyRepository;
+
+    @Override
+    public AnimationFramesResponseDTO getAnimaitonFrames(AnimationType animationType, Long userId) {
+
+        // 유저의 강아지 찾기
+        Puppy puppy = puppyRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 해당하는 애니메이션 찾기
+        PuppyAnimation puppyAnimation = puppyAnimationRepository.findByAnimationTypeAndPuppyTypeAndLevelName(
+                        animationType,
+                        puppy.getPuppyLevel().getPuppyType(),
+                        puppy.getPuppyLevel().getLevelName()
+                ).orElseThrow(() -> new IllegalArgumentException("해당하는 애니메이션을 찾을 수 없습니다."));
+
+        // 애니메이션 프레임 가져오기
+        List<PuppyAnimationImage> animationImages = puppyAnimation.getAnimationImages();
+
+        // 이미지 URL 순서대로 정리
+        List<String> imageUrls = animationImages.stream()
+                .sorted(Comparator.comparingInt(PuppyAnimationImage::getFrameOrder))
+                .map(PuppyAnimationImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        return new AnimationFramesResponseDTO(animationType, imageUrls.size(), imageUrls);
+
+    }
+
+}

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -1,5 +1,6 @@
 package umc.puppymode.service.PuppyService;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.puppymode.domain.Puppy;
@@ -84,6 +85,7 @@ public class PuppyItemServiceImpl implements PuppyItemService {
     }
 
     @Override
+    @Transactional
     public Map<String, Object> purchaseItem(Long categoryId, Long itemId, Long userId) {
         // 유저 찾기
         User user = userRepository.findById(userId)
@@ -142,10 +144,8 @@ public class PuppyItemServiceImpl implements PuppyItemService {
     }
 
     @Override
+    @Transactional
     public Map<String, Object> equipItem(Long categoryId, Long itemId, Long userId) {
-        // 유저 찾기
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
         // 유저의 강아지 찾기
         Puppy puppy = puppyRepository.findByUserId(userId)
@@ -197,6 +197,7 @@ public class PuppyItemServiceImpl implements PuppyItemService {
     }
 
     @Override
+    @Transactional
     public Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId) {
         // 유저 찾기
         User user = userRepository.findById(userId)

--- a/src/main/java/umc/puppymode/web/controller/PuppyAnimationController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyAnimationController.java
@@ -1,0 +1,31 @@
+package umc.puppymode.web.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.puppymode.apiPayload.ApiResponse;
+import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.service.PuppyService.PuppyAnimationService;
+import umc.puppymode.service.UserService.UserAuthService;
+import umc.puppymode.web.dto.AnimationFramesResponseDTO;
+
+
+@RestController
+@RequestMapping("/puppies/animations")
+@RequiredArgsConstructor
+public class PuppyAnimationController {
+    private final PuppyAnimationService puppyAnimationService;
+    private final UserAuthService userAuthService;
+
+    @Operation(summary = "애니메이션 프레임 조회 API", description = "강아지 애니메이션의 프레임 이미지 목록을 조회하는 API")
+    @GetMapping("/frames")
+    public ApiResponse<AnimationFramesResponseDTO> getAnimationFrames(
+            @RequestParam AnimationType animationType) {
+        Long userId = userAuthService.getCurrentUserId();
+        AnimationFramesResponseDTO animationFramesResponseDTO = puppyAnimationService.getAnimaitonFrames(animationType, userId);
+        return ApiResponse.onSuccess(animationFramesResponseDTO);
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/AnimationFramesResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/AnimationFramesResponseDTO.java
@@ -1,0 +1,15 @@
+package umc.puppymode.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.puppymode.domain.enums.AnimationType;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AnimationFramesResponseDTO{
+    private AnimationType animationType;
+    private int frameCount;
+    private List<String> imageUrls;
+}


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
놀아주기 등 강아지와 상호작용 시에 실행되는 애니메이션의 프레임 이미지 목록을 조회하는 API를 구현하였습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #39

## ⏳ 작업 내용
- 애니메이션 프레임 조회 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
