### PR TITLE
[Feat] 컬렉션 업데이트 및 아이템 획득 기능 구현 #103

### DIFF
--- a/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/puppymode/apiPayload/code/status/ErrorStatus.java
@@ -42,7 +42,8 @@ public enum ErrorStatus implements BaseErrorCode {
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
 
     // 강아지 관련 예외 처리
-    PUPPY_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY404", "해당 ID를 가진 강아지를 찾을 수 없습니다."),
+    PUPPY_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY4041", "해당 ID를 가진 강아지를 찾을 수 없습니다."),
+    NO_USERS_PUPPY(HttpStatus.NOT_FOUND, "PUPPY4042", "해당 사용자의 강아지가 존재하지 않습니다."),
     UNAUTHORIZED_PUPPY_ACCESS(HttpStatus.UNAUTHORIZED, "PUPPY401", "강아지에 대한 접근 권한이 없습니다."),
     PUPPY_ALREADY_EXISTS(HttpStatus.CONFLICT, "PUPPY409", "최대 강아지 보유량을 초과하였습니다. (최대: 1)"),
 

--- a/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
+++ b/src/main/java/umc/puppymode/domain/mapping/PuppyCustomization.java
@@ -1,7 +1,6 @@
 package umc.puppymode.domain.mapping;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import jakarta.persistence.*;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyItem;
@@ -12,6 +11,9 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PuppyCustomization {
 
     @Id

--- a/src/main/java/umc/puppymode/domain/mapping/UserCollection.java
+++ b/src/main/java/umc/puppymode/domain/mapping/UserCollection.java
@@ -29,4 +29,9 @@ public class UserCollection extends BaseEntity {
 
     // 달성 여부
     private boolean isCompleted;
+
+    public boolean updateCurrentNumAndReturnIsCompleted() {
+        this.currentNum++;
+        return this.currentNum.equals(collection.getRequiredNum());
+    }
 }

--- a/src/main/java/umc/puppymode/repository/UserCollectionRepository.java
+++ b/src/main/java/umc/puppymode/repository/UserCollectionRepository.java
@@ -13,4 +13,6 @@ public interface UserCollectionRepository extends JpaRepository<UserCollection, 
     @Query("SELECT u FROM UserCollection u WHERE u.user = :user ORDER BY u.isCompleted ASC, (u.collection.requiredNum - u.currentNum) ASC, u.userCollectionId ASC")
         // 달성되지 않은 것부터 보여주되, 그 내에서는 달성까지 적게 남은 것부터 보여주고, 그 내에서는 id 기준으로 정렬
     List<UserCollection> findByUserOrderByIsCompleted(@Param("user") User user);
+
+    List<UserCollection> findByUser(User user);
 }

--- a/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkService/DrinkCommandServiceImpl.java
@@ -9,6 +9,7 @@ import umc.puppymode.domain.*;
 import umc.puppymode.domain.enums.FeedingItem;
 import umc.puppymode.domain.enums.PuppyType;
 import umc.puppymode.repository.*;
+import umc.puppymode.service.UserCollectionService.UserCollectionCommandService;
 import umc.puppymode.web.dto.DrinkRequestDTO.*;
 import umc.puppymode.web.dto.DrinkResponseDTO.*;
 
@@ -26,6 +27,7 @@ public class DrinkCommandServiceImpl implements DrinkCommandService {
     private final HangoverRepository hangoverRepository;
     private final PuppyRepository puppyRepository;
     private final FeedRepository feedRepository;
+    private final UserCollectionCommandService userCollectionCommandService;
 
     @Override
     public DrinksRecordResponseDTO postDrinksRecord(Long userId, DrinkRecordDTO drinkRecordDTO) {
@@ -71,7 +73,7 @@ public class DrinkCommandServiceImpl implements DrinkCommandService {
         }
 
         Puppy puppy = puppyRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));;
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_USERS_PUPPY));;
         recordResponseDTO.setPuppyLevel(puppy.getPuppyLevel().getPuppyLevel());
         recordResponseDTO.setPuppyLevelName(puppy.getPuppyLevel().getLevelName());
         recordResponseDTO.setPuppyPercent(puppy.getPuppyExp());
@@ -91,13 +93,18 @@ public class DrinkCommandServiceImpl implements DrinkCommandService {
 
         feedRepository.save(feed);
 
+        // 경험 숙취 증상 목록에 따른 해당 유저의 컬렉션 업데이트
+        if (!hangoverItems.isEmpty()) {
+            userCollectionCommandService.updateCollection(user, hangoverItems);
+        }
+
         return recordResponseDTO;
     }
 
     @Override
     public FeedResponseDTO postFeed(Long userId) {
         Puppy puppy = puppyRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_USERS_PUPPY));
 
         // 현재 레벨의 최소 ~ 최대 경험치 차이를 기준으로 5% 증가
         Integer fivePercentExp = (int) ((puppy.getPuppyLevel().getLevelMaxExp() - puppy.getPuppyLevel().getLevelMinExp()) * 0.05);

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyQueryServiceImpl.java
@@ -24,7 +24,7 @@ public class MainPuppyQueryServiceImpl implements MainPuppyQueryService {
     public MainPuppyResDTO.UserPuppyViewDTO getUserPuppy(Long userId) {
 
         userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
-        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
+        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new TempHandler(ErrorStatus.NO_USERS_PUPPY));
 
         return MainPuppyConverter.toUserPuppyViewDTO(puppy);
     }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -124,7 +124,7 @@ public class PuppyItemServiceImpl implements PuppyItemService {
 
         // 포인트 차감 및 아이템 구매 처리
         user.setPoints(user.getPoints() - item.getPrice());
-        PuppyCustomization customization = new PuppyCustomization();
+        PuppyCustomization customization = PuppyCustomization.builder().build();
         customization.setPuppy(puppy);
         customization.setPuppyItem(item);
         customization.setPuppyItemCategory(puppyItemCategory);

--- a/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandService.java
+++ b/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandService.java
@@ -1,0 +1,16 @@
+package umc.puppymode.service.UserCollectionService;
+
+import umc.puppymode.domain.HangoverItem;
+import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.User;
+
+import java.util.List;
+
+public interface UserCollectionCommandService {
+
+    // 경험 숙취 증상 목록에 따른 해당 유저의 컬렉션 업데이트
+    void updateCollection(User user, List<HangoverItem> hangoverItems);
+
+    // 보상 아이템 획득
+    void getRewardItem(PuppyItem puppyItem, Long userId);
+}

--- a/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandServiceImpl.java
@@ -1,0 +1,72 @@
+package umc.puppymode.service.UserCollectionService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.puppymode.apiPayload.code.status.ErrorStatus;
+import umc.puppymode.apiPayload.exception.GeneralException;
+import umc.puppymode.domain.HangoverItem;
+import umc.puppymode.domain.Puppy;
+import umc.puppymode.domain.PuppyItem;
+import umc.puppymode.domain.User;
+import umc.puppymode.domain.mapping.PuppyCustomization;
+import umc.puppymode.domain.mapping.UserCollection;
+import umc.puppymode.repository.PuppyCustomizationRepository;
+import umc.puppymode.repository.PuppyRepository;
+import umc.puppymode.repository.UserCollectionRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserCollectionCommandServiceImpl implements UserCollectionCommandService {
+
+    private final UserCollectionRepository userCollectionRepository;
+    private final PuppyRepository puppyRepository;
+    private final PuppyCustomizationRepository puppyCustomizationRepository;
+
+    @Override
+    // 경험 숙취 증상 목록에 따른 해당 유저의 컬렉션 업데이트
+    public void updateCollection(User user, List<HangoverItem> hangoverItems) {
+
+        List<UserCollection> userCollections = userCollectionRepository.findByUser(user);
+
+        // HangoverItem을 키 값으로 하는 Map 생성
+        Map<HangoverItem, List<UserCollection>> userCollectionMap = userCollections.stream()
+                .collect(Collectors.groupingBy(u -> u.getCollection().getHangoverItem()));
+
+        // 숙취 증상에 해당하는 userCollection 목록에 대하여 달성 횟수 업데이트
+        for (HangoverItem hangoverItem : hangoverItems) {
+            List<UserCollection> collections = userCollectionMap.get(hangoverItem);
+            if (collections != null) {
+                for (UserCollection userCollection : collections) {
+                    if (userCollection.updateCurrentNumAndReturnIsCompleted()) {
+                        // 조건 충족(요구 횟수 만족) 시 보상 아이템 획득
+                        userCollection.setCompleted(true);
+                        getRewardItem(userCollection.getCollection().getPuppyItem(), user.getUserId());
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    // 보상 아이템 획득
+    public void getRewardItem(PuppyItem puppyItem, Long userId) {
+
+        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new GeneralException(ErrorStatus.NO_USERS_PUPPY));
+
+        // puppyCustomization 객체 생성 (강아지가 아이템을 획득한 것을 의미)
+        PuppyCustomization puppyCustomization = PuppyCustomization.builder()
+                .puppy(puppy)
+                .puppyItem(puppyItem)
+                .puppyItemCategory(puppyItem.getCategory())
+                .isEquipped(false)
+                .build();
+
+        puppyCustomizationRepository.save(puppyCustomization);
+    }
+}

--- a/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserCollectionService/UserCollectionCommandServiceImpl.java
@@ -43,10 +43,13 @@ public class UserCollectionCommandServiceImpl implements UserCollectionCommandSe
             List<UserCollection> collections = userCollectionMap.get(hangoverItem);
             if (collections != null) {
                 for (UserCollection userCollection : collections) {
-                    if (userCollection.updateCurrentNumAndReturnIsCompleted()) {
-                        // 조건 충족(요구 횟수 만족) 시 보상 아이템 획득
-                        userCollection.setCompleted(true);
-                        getRewardItem(userCollection.getCollection().getPuppyItem(), user.getUserId());
+                    // 이미 완료된 컬렉션이 아닌 경우에만 수행
+                    if (!userCollection.isCompleted()) {
+                        if (userCollection.updateCurrentNumAndReturnIsCompleted()) {
+                            // 조건 충족(요구 횟수 만족) 시 보상 아이템 획득
+                            userCollection.setCompleted(true);
+                            getRewardItem(userCollection.getCollection().getPuppyItem(), user.getUserId());
+                        }
                     }
                 }
             }

--- a/src/main/java/umc/puppymode/service/UserService/UserQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserQueryServiceImpl.java
@@ -33,6 +33,6 @@ public class UserQueryServiceImpl implements UserQueryService {
     @Override
     public Puppy getUserPuppy(Long userId) {
         return puppyRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NO_USERS_PUPPY));
     }
 }


### PR DESCRIPTION
# 🚀 개요
- b54f1bb1955bfba7c4843394666de77f620c56fa 
    - 음주 기록 생성 api 내에서
        - 선택된 hangoverOptions에 대해 해당하는 컬렉션 달성 횟수 업데이트
        - 위의 과정에서 달성 횟수가 목표 횟수와 같아질 경우 지정된 아이템을 획득

    - NO_USERS_PUPPY 에러 추가 및 반영 -> 특정 userId에 해당하는 강아지가 없을 시, 즉 사용자의 강아지가 없을 시 반환
        - 특정 puppyId에 해당하는 강아지가 없을 경우 사용하는 PUPPY_NOT_FOUND와는 다른 의미를 가짐

    - PuppyCustomization 엔티티 빌더패턴 적용

- b5514f321507ff452f4a0768feb48d5cb1f80e59
    - 선택된 숙취에 해당하는 컬렉션이더라도, 이미 완료된 상태일 경우 currentNum을 업데이트하지 않도록 수정

</br>
</br>

위 구현 기능들에 대해, 임시 컨트롤러의 api를 사용하여 간단한 스웨거 동작 테스트 완료

</br>

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #103 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
