### PR TITLE
[Refactor] puppyId 필요 시 JWT 사용 리팩토링 #105

### DIFF
--- a/src/main/java/umc/puppymode/repository/PuppyRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyRepository.java
@@ -1,16 +1,13 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import umc.puppymode.domain.Puppy;
-import umc.puppymode.domain.User;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
+import umc.puppymode.domain.Puppy;
 
 import java.util.Optional;
 
 public interface PuppyRepository extends JpaRepository<Puppy, Long> {
-    Optional<Puppy> findByUser(User user);
   
     @Query("SELECT p FROM Puppy p WHERE p.user.userId = :userId")
     Optional<Puppy> findByUserId(@Param("userId")Long userId);

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandService.java
@@ -7,9 +7,9 @@ public interface MainPuppyCommandService {
     // 랜덤으로 강아지를 선택
     MainPuppyResDTO.RandomPuppyViewDTO getRandomPuppy(Long userId);
     // 강아지의 이름을 수정
-    String updatePuppyName(Long userId, Long puppyId, String newPuppyName);
+    String updatePuppyName(Long userId, String newPuppyName);
     // 강아지 놀아주기 실행
-    MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId, Long puppyId);
+    MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId);
     // 사용자의 강아지 객체 삭제
     String deletePuppy(Long userId);
 }

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
@@ -57,14 +57,11 @@ public class MainPuppyCommandServiceImpl implements MainPuppyCommandService {
 
     @Override
     // 강아지의 이름을 수정
-    public String updatePuppyName(Long userId, Long puppyId, String newPuppyName) {
+    public String updatePuppyName(Long userId, String newPuppyName) {
 
         userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
-        Puppy puppy = puppyRepository.findById(puppyId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
-        // 강아지가 현재 사용자의 강아지가 아닌 경우 에러 발생
-        if (!userId.equals(puppy.getUser().getUserId())) {
-            throw new TempHandler(ErrorStatus.UNAUTHORIZED_PUPPY_ACCESS);
-        }
+        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new TempHandler(ErrorStatus.NO_USERS_PUPPY));
+
         puppy.updatePuppyName(newPuppyName);
 
         return puppy.getPuppyName();
@@ -72,14 +69,11 @@ public class MainPuppyCommandServiceImpl implements MainPuppyCommandService {
 
     @Override
     // 강아지 놀아주기 실행
-    public MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId, Long puppyId) {
+    public MainPuppyResDTO.PlayResDTO platWithPuppy(Long userId) {
 
         User user = userRepository.findById(userId).orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
-        Puppy puppy = puppyRepository.findById(puppyId).orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_NOT_FOUND));
-        // 강아지가 현재 사용자의 강아지가 아닌 경우 에러 발생
-        if (!userId.equals(puppy.getUser().getUserId())) {
-            throw new TempHandler(ErrorStatus.UNAUTHORIZED_PUPPY_ACCESS);
-        }
+        Puppy puppy = puppyRepository.findByUserId(userId).orElseThrow(() -> new TempHandler(ErrorStatus.NO_USERS_PUPPY));
+
         // 사용자 포인트 10p 증가
         user.updatePoints(10);
         // 현재 레벨의 전체 경험치의 1% 만큼의 경험치 계산

--- a/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
+++ b/src/main/java/umc/puppymode/web/controller/MainPuppyController.java
@@ -40,21 +40,19 @@ public class MainPuppyController {
     @PatchMapping
     @Operation(summary = "강아지 이름 수정 API", description = "강아지의 이름을 수정하는 API입니다.")
     public ApiResponse<String> updatePuppyName(
-            @RequestParam Long puppyId,
             @RequestParam String newPuppyName) {
 
         Long userId = userAuthService.getCurrentUserId();
-        String updatedPuppyName = mainPuppyCommandService.updatePuppyName(userId, puppyId, newPuppyName);
+        String updatedPuppyName = mainPuppyCommandService.updatePuppyName(userId, newPuppyName);
         return ApiResponse.onSuccess(updatedPuppyName);
     }
 
     @PostMapping("/play")
     @Operation(summary = "강아지 놀아주기 API", description = "강아지 놀아주기를 실행하는 API입니다.")
-    public ApiResponse<MainPuppyResDTO.PlayResDTO> playWithPuppy(
-            @RequestParam Long puppyId) {
+    public ApiResponse<MainPuppyResDTO.PlayResDTO> playWithPuppy() {
 
         Long userId = userAuthService.getCurrentUserId();
-        MainPuppyResDTO.PlayResDTO playResDTO = mainPuppyCommandService.platWithPuppy(userId, puppyId);
+        MainPuppyResDTO.PlayResDTO playResDTO = mainPuppyCommandService.platWithPuppy(userId);
         return ApiResponse.onSuccess(playResDTO);
     }
 


### PR DESCRIPTION
# 🚀 개요
- 강아지 이름 수정, 강아지 놀아주기 api에서 puppyId를 파라미터로 받지 않고 jwt를 통해 userId로 puppy 객체 찾도록 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #105 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
