### PR TITLE
[Feat] 강아지 hard delete 및 생성 api 수정 #110

### DIFF
--- a/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
+++ b/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
@@ -16,14 +16,10 @@ public class MainPuppyConverter {
     }
 
     public static MainPuppyResDTO.UserPuppyViewDTO toUserPuppyViewDTO(Puppy puppy) {
-        // 사용자 지정 강아지 이름이 null일 시 단계명으로 대체 (figma 정책 반영)
-        String puppyName = puppy.getPuppyName();
-        if (puppyName == null) {
-            puppyName = puppy.getPuppyLevel().getLevelName();
-        }
+
         return MainPuppyResDTO.UserPuppyViewDTO.builder()
                 .puppyId(puppy.getPuppyId())
-                .puppyName(puppyName)
+                .puppyName(puppy.getPuppyName())
                 .level(puppy.getPuppyLevel().getPuppyLevel())
                 .levelName(puppy.getPuppyLevel().getLevelName())
                 .imageUrl(puppy.getPuppyLevel().getLevelImageUrl())
@@ -43,9 +39,14 @@ public class MainPuppyConverter {
     }
 
     public static Puppy toPuppy(PuppyLevel puppyLevel, User user) {
+
+        // 초기 강아지 이름을 강아지 레벨 이름으로 대체 (figma 정책 반영)
+        String puppyName = puppyLevel.getLevelName();
+
         return Puppy.builder()
                 .user(user)
                 .puppyLevel(puppyLevel)
+                .puppyName(puppyName)
                 .puppyExp(0)
                 .build();
     }

--- a/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
@@ -1,6 +1,8 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyItem;
 import umc.puppymode.domain.PuppyItemCategory;
@@ -14,4 +16,7 @@ public interface PuppyCustomizationRepository extends JpaRepository<PuppyCustomi
     Optional<PuppyCustomization> findByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
     Optional<PuppyCustomization> findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(Puppy puppy, PuppyItemCategory puppyItemCategory);
     List<PuppyCustomization> findByPuppy(Puppy puppy);
+
+    @Query("SELECT p FROM PuppyCustomization p WHERE p.puppy.puppyId = :puppyId")
+    List<PuppyCustomization> findByPuppyId(@Param("puppyId")Long puppyId);
 }

--- a/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/MainPuppyService/MainPuppyCommandServiceImpl.java
@@ -10,6 +10,8 @@ import umc.puppymode.converter.MainPuppyConverter;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyLevel;
 import umc.puppymode.domain.User;
+import umc.puppymode.domain.mapping.PuppyCustomization;
+import umc.puppymode.repository.PuppyCustomizationRepository;
 import umc.puppymode.repository.PuppyLevelRepository;
 import umc.puppymode.repository.PuppyRepository;
 import umc.puppymode.repository.UserRepository;
@@ -27,6 +29,7 @@ public class MainPuppyCommandServiceImpl implements MainPuppyCommandService {
     private final PuppyRepository puppyRepository;
     private final UserRepository userRepository;
     private final PuppyLevelRepository puppyLevelRepository;
+    private final PuppyCustomizationRepository puppyCustomizationRepository;
 
     @Override
     // 랜덤으로 강아지를 선택
@@ -91,6 +94,13 @@ public class MainPuppyCommandServiceImpl implements MainPuppyCommandService {
         Optional<Puppy> puppy = puppyRepository.findByUserId(userId);
         if (puppy.isPresent()) {
             Long puppyId = puppy.get().getPuppyId();
+
+            // 강아지 커스터마이징 객체 삭제
+            List<PuppyCustomization> customizations = puppyCustomizationRepository.findByPuppyId(puppyId);
+            if (!customizations.isEmpty()) {
+                puppyCustomizationRepository.deleteAll(customizations);
+            }
+
             puppyRepository.delete(puppy.get());
             return "강아지 객체가 성공적으로 삭제되었습니다. 삭제된 puppyId: " + puppyId;
         } else {


### PR DESCRIPTION
# 🚀 개요
- puppy 생성 시 default 이름을 puppyLevel 이름으로 출력되도록 수정
    - 이전 수정 때 착오로 인하여 db에 저장되는 값이 아닌 api의 ResDTO에서만 puppyLevelName을 표시하도록 구현함

- 강아지 hard delete 시 puppy_customization 테이블에서 해당 puppy의 기록 삭제 후 delete 진행하도록 구현 (FK)

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #110 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
