### PR TITLE
[Refactor] Puppy에 Image URL 추가 #112

### DIFF
--- a/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
+++ b/src/main/java/umc/puppymode/converter/MainPuppyConverter.java
@@ -11,7 +11,7 @@ public class MainPuppyConverter {
         return MainPuppyResDTO.RandomPuppyViewDTO.builder()
                 .userId(puppy.getUser().getUserId())
                 .puppyType(puppy.getPuppyLevel().getPuppyType().getType())
-                .puppyImageUrl(puppy.getPuppyLevel().getLevelImageUrl())
+                .puppyImageUrl(puppy.getImageUrl())
                 .build();
     }
 
@@ -22,7 +22,7 @@ public class MainPuppyConverter {
                 .puppyName(puppy.getPuppyName())
                 .level(puppy.getPuppyLevel().getPuppyLevel())
                 .levelName(puppy.getPuppyLevel().getLevelName())
-                .imageUrl(puppy.getPuppyLevel().getLevelImageUrl())
+                .imageUrl(puppy.getImageUrl())
                 .levelMinExp(puppy.getPuppyLevel().getLevelMinExp())
                 .levelMaxExp(puppy.getPuppyLevel().getLevelMaxExp())
                 .puppyExp(puppy.getPuppyExp())
@@ -48,6 +48,7 @@ public class MainPuppyConverter {
                 .puppyLevel(puppyLevel)
                 .puppyName(puppyName)
                 .puppyExp(0)
+                .imageUrl(puppyLevel.getLevelImageUrl())
                 .build();
     }
 }

--- a/src/main/java/umc/puppymode/domain/Puppy.java
+++ b/src/main/java/umc/puppymode/domain/Puppy.java
@@ -31,6 +31,8 @@ public class Puppy extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CustomizingItem puppyItem;
 
+    private String imageUrl;
+
     public void updatePuppyName(String puppyName) {
         this.puppyName = puppyName;
     }

--- a/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/FcmService/FcmPlaytimeServiceImpl.java
@@ -61,7 +61,7 @@ public class FcmPlaytimeServiceImpl implements FcmPlaytimeService {
                                     .token(token)
                                     .title("오늘도 " + puppy.getPuppyName() + "랑 놀아주세요.")
                                     .body(puppy.getPuppyName() + "가 주인님을 애타게 기다리고 있어요.")
-                                    .image(puppy.getPuppyLevel().getLevelImageUrl())
+                                    .image(puppy.getImageUrl())
                                     .build()
                     );
                 } catch (Exception e) {


### PR DESCRIPTION
# 🚀 개요
- 각 강아지의 이미지를 나타내는 image url을 puppyLevel 테이블에서 얻는 것이 아닌, puppy 객체의 imageUrl(추가됨)을 통해 얻도록 수정했습니다.

- 윤지님 말씀 들어보니 현재 아이템 착용 로직을 수정하지 않는 것이 맞아 보여서, 일단은 강아지 생성 시 default imageUrl을 저장하는 부분까지만 구현해서 pr 올렸습니다!!
추후에 착용된 아이템 조회 api 구현된 후 알려주시면, 해당 api를 사용하여 <default puppy image와 transparent item images>를 함께 반환하는 로직 구현해보겠습니다...!

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #112 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
