### PR TITLE
[FEAT] 강아지 꾸미기 관련 API 추가 #113

### DIFF
--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
@@ -1,5 +1,8 @@
 package umc.puppymode.service.PuppyService;
 
+import umc.puppymode.web.dto.PuppyCustomDTO.ItemResponseDTO;
+
+import java.util.List;
 import java.util.Map;
 
 public interface PuppyItemService {
@@ -8,4 +11,6 @@ public interface PuppyItemService {
     Map<String, Object> purchaseItem(Long categoryId, Long itemId, Long userId);
     Map<String, Object> equipItem(Long categoryId, Long itemId, Long userId);
     Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId);
+    Integer getPoints(Long userId);
+    List<ItemResponseDTO> getOwnedItems(Long userId);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -9,10 +9,10 @@ import umc.puppymode.domain.PuppyItemCategory;
 import umc.puppymode.domain.EquippedItemImage;
 import umc.puppymode.domain.mapping.PuppyCustomization;
 import umc.puppymode.repository.*;
-import umc.puppymode.web.dto.EquippedItemInfoDTO;
-import umc.puppymode.web.dto.ItemCategoryResponseDTO;
+import umc.puppymode.web.dto.PuppyCustomDTO.EquippedItemInfoDTO;
+import umc.puppymode.web.dto.PuppyCustomDTO.ItemCategoryResponseDTO;
 import umc.puppymode.domain.User;
-import umc.puppymode.web.dto.ItemResponseDTO;
+import umc.puppymode.web.dto.PuppyCustomDTO.ItemResponseDTO;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -166,7 +166,6 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         PuppyCustomization customization = puppyCustomizationRepository.findByPuppyAndPuppyItem(puppy, item)
                 .orElseThrow(() -> new IllegalArgumentException("구매하지 않은 아이템입니다."));
 
-
         // 같은 카테고리에서 현재 착용 중인 아이템 해제
         PuppyCustomization currentEquippedItem = puppyCustomizationRepository.findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(puppy, puppyItemCategory)
                 .orElse(null);
@@ -234,6 +233,43 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         result.put("unequippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
 
         return result;
+    }
+
+    @Override
+    public Integer getPoints(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+
+        return user.getPoints();
+    }
+
+    @Override
+    public List<ItemResponseDTO> getOwnedItems(Long userId) {
+        // 유저의 강아지 찾기
+        Puppy puppy = puppyRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 모든 아이템 조회
+        List<PuppyItem> items = itemRepository.findAll();
+
+        // 유저가 소유한 아이템 리스트
+        List<Long> OwnedItemIds = puppyCustomizationRepository.findByPuppy(puppy).stream()
+                .map(customization -> customization.getPuppyItem().getItemId())
+                .collect(Collectors.toList());
+
+        List<ItemResponseDTO> itemResponseList = items.stream()
+                .filter(item -> OwnedItemIds.contains(item.getItemId())) // 소유한 아이템만 필터링
+                .map(item -> new ItemResponseDTO(
+                        item.getItemId(),
+                        item.getItemName(),
+                        item.getPrice(),
+                        item.getImageUrl(),
+                        OwnedItemIds.contains(item.getItemId()),
+                        item.getMission_item()
+                ))
+                .collect(Collectors.toList());
+
+        return itemResponseList;
     }
 
 }

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -7,7 +7,9 @@ import umc.puppymode.service.PuppyService.PuppyItemService;
 import umc.puppymode.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import umc.puppymode.service.UserService.UserAuthService;
+import umc.puppymode.web.dto.PuppyCustomDTO.ItemResponseDTO;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -26,7 +28,7 @@ public class PuppyItemController {
                 true,
                 "SUCCESS_GET_PUPPY_CATEGORIES",
                 "카테고리 목록 조회 성공",
-                categories // Map 형태로 반환
+                categories
         );
     }
 
@@ -39,7 +41,7 @@ public class PuppyItemController {
                 true,
                 "SUCCESS_GET_PUPPY_CATEGORY_ITEMS",
                 "카테고리 별 아이템 목록 조회 성공",
-                puppyItemService.getItemsByCategory(categoryId, userId) // Map 형태로 반환
+                puppyItemService.getItemsByCategory(categoryId, userId)
         );
     }
 
@@ -57,7 +59,7 @@ public class PuppyItemController {
         );
     }
 
-    @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API")
+    @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API(이미지는 강아지 상태에 따른 아이템 단일 이미지로, 레이어드 할 투명 배경 이미지입니다)")
     @PostMapping("/{categoryId}/items/{itemId}/equip")
     public ApiResponse<Map<String, Object>> equipItem(@PathVariable Long categoryId,
                                                       @PathVariable Long itemId) {
@@ -75,6 +77,30 @@ public class PuppyItemController {
 
         Map<String, Object> result = puppyItemService.unequipItem(categoryId, itemId, userId);
         return ResponseEntity.ok(new ApiResponse<>(true, "SUCCESS_UNEQUIP_PUPPY_ITEM", "아이템 착용 해제 성공", result));
+    }
+
+    @Operation(summary = "포인트 조회 API", description = "유저의 현재 포인트를 조회하는 API")
+    @GetMapping("/points")
+    public ApiResponse<Integer> getPoints() {
+        Long userId = userAuthService.getCurrentUserId();
+        return new ApiResponse<>(
+                true,
+                "SUCCESS_GET_POINTS",
+                "포인트 조회 성공",
+                puppyItemService.getPoints(userId));
+    }
+
+    @Operation(summary = "소유한 아이템 목록 조회 API", description = "유저가 소유한 아이템 목록을 조회하는 API")
+    @GetMapping("/items")
+    public ApiResponse<List<ItemResponseDTO>> getOwnedItems() {
+        Long userId = userAuthService.getCurrentUserId();
+        List<ItemResponseDTO> result = puppyItemService.getOwnedItems(userId);
+
+        return new ApiResponse<>(
+                true,
+                "SUCCESS_GET_OWNED_ITEMS",
+                "소유한 아이템 목록 조회 성공",
+                result);
     }
 
 

--- a/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/EquippedItemInfoDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/EquippedItemInfoDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.PuppyCustomDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/ItemCategoryResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/ItemCategoryResponseDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.PuppyCustomDTO;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/ItemResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/ItemResponseDTO.java
@@ -1,4 +1,4 @@
-package umc.puppymode.web.dto;
+package umc.puppymode.web.dto.PuppyCustomDTO;
 
 
 import lombok.AllArgsConstructor;
@@ -7,6 +7,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+
 @AllArgsConstructor
 public class ItemResponseDTO {
     private Long itemId; // 아이템 ID


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
강아지 꾸미기 관련 API 목록에 추가된 유저 포인트 조회 API, 소유한 아이템 목록 조회 API를 추가 구현하였습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #113

## ⏳ 작업 내용
- 유저 포인트 조회 API 구현
- 소유한 아이템 목록 조회 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
