### PR TITLE
[FEAT] 착용 아이템 목록 조회 API 구현 #116

### DIFF
--- a/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyCustomizationRepository.java
@@ -16,6 +16,7 @@ public interface PuppyCustomizationRepository extends JpaRepository<PuppyCustomi
     Optional<PuppyCustomization> findByPuppyAndPuppyItem(Puppy puppy, PuppyItem item);
     Optional<PuppyCustomization> findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(Puppy puppy, PuppyItemCategory puppyItemCategory);
     List<PuppyCustomization> findByPuppy(Puppy puppy);
+    List<PuppyCustomization> findByPuppyAndIsEquippedTrue(Puppy puppy);
 
     @Query("SELECT p FROM PuppyCustomization p WHERE p.puppy.puppyId = :puppyId")
     List<PuppyCustomization> findByPuppyId(@Param("puppyId")Long puppyId);

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemService.java
@@ -1,5 +1,6 @@
 package umc.puppymode.service.PuppyService;
 
+import umc.puppymode.web.dto.PuppyCustomDTO.EquippedItemInfoDTO;
 import umc.puppymode.web.dto.PuppyCustomDTO.ItemResponseDTO;
 
 import java.util.List;
@@ -9,8 +10,9 @@ public interface PuppyItemService {
     Map<String, Object> getAllCategories();
     Map<String, Object> getItemsByCategory(Long categoryId, Long userId);
     Map<String, Object> purchaseItem(Long categoryId, Long itemId, Long userId);
-    Map<String, Object> equipItem(Long categoryId, Long itemId, Long userId);
-    Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId);
+    EquippedItemInfoDTO equipItem(Long categoryId, Long itemId, Long userId);
+    EquippedItemInfoDTO unequipItem(Long categoryId, Long itemId, Long userId);
     Integer getPoints(Long userId);
     List<ItemResponseDTO> getOwnedItems(Long userId);
+    List<EquippedItemInfoDTO> getEquippedItems(Long userId);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -145,7 +145,7 @@ public class PuppyItemServiceImpl implements PuppyItemService {
 
     @Override
     @Transactional
-    public Map<String, Object> equipItem(Long categoryId, Long itemId, Long userId) {
+    public EquippedItemInfoDTO equipItem(Long categoryId, Long itemId, Long userId) {
 
         // 유저의 강아지 찾기
         Puppy puppy = puppyRepository.findByUserId(userId)
@@ -180,24 +180,19 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         puppyCustomizationRepository.save(customization);
 
         // 아이템 착용 이미지
-        String updatedImageUrl = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
+        String equippedImage = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
                 puppy.getPuppyLevel().getPuppyType(),
                 puppy.getPuppyLevel().getLevelName(),
                 itemId
         ).map(EquippedItemImage::getImageUrl)
                 .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
 
-        // 응답 데이터 구성
-        Map<String, Object> result = new HashMap<>();
-        result.put("updatedPuppyImageUrl", updatedImageUrl);
-        result.put("equippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
-
-        return result;
+        return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), equippedImage);
     }
 
     @Override
     @Transactional
-    public Map<String, Object> unequipItem(Long categoryId, Long itemId, Long userId) {
+    public EquippedItemInfoDTO unequipItem(Long categoryId, Long itemId, Long userId) {
         // 유저 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
@@ -229,10 +224,15 @@ public class PuppyItemServiceImpl implements PuppyItemService {
             throw new IllegalArgumentException("이미 착용하지 않은 아이템입니다.");
         }
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("unequippedItemInfo", new EquippedItemInfoDTO(item.getItemId(), item.getItemName()));
+        // 아이템 착용 이미지
+        String equippedImage = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
+                        puppy.getPuppyLevel().getPuppyType(),
+                        puppy.getPuppyLevel().getLevelName(),
+                        itemId
+                ).map(EquippedItemImage::getImageUrl)
+                .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
 
-        return result;
+        return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), equippedImage);
     }
 
     @Override
@@ -270,6 +270,34 @@ public class PuppyItemServiceImpl implements PuppyItemService {
                 .collect(Collectors.toList());
 
         return itemResponseList;
+    }
+
+    @Override
+    public List<EquippedItemInfoDTO> getEquippedItems(Long userId) {
+        // 유저의 강아지 찾기
+        Puppy puppy = puppyRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다."));
+
+        // 구매한 아이템 목록
+        List<PuppyCustomization> equippedItems = puppyCustomizationRepository.findByPuppyAndIsEquippedTrue(puppy);
+
+        // 리스트 변환
+        List<EquippedItemInfoDTO> equippedItemInfoDTOList = equippedItems.stream()
+                .map(customization -> {
+                    PuppyItem item = customization.getPuppyItem();
+                    // 아이템 착용 이미지
+                    String equippedImage = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
+                                    puppy.getPuppyLevel().getPuppyType(),
+                                    puppy.getPuppyLevel().getLevelName(),
+                                    item.getItemId()
+                            ).map(EquippedItemImage::getImageUrl)
+                            .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
+
+                    return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), equippedImage);
+                })
+                .collect(Collectors.toList());
+
+        return equippedItemInfoDTOList;
     }
 
 }

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -7,6 +7,7 @@ import umc.puppymode.service.PuppyService.PuppyItemService;
 import umc.puppymode.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import umc.puppymode.service.UserService.UserAuthService;
+import umc.puppymode.web.dto.PuppyCustomDTO.EquippedItemInfoDTO;
 import umc.puppymode.web.dto.PuppyCustomDTO.ItemResponseDTO;
 
 import java.util.List;
@@ -61,22 +62,22 @@ public class PuppyItemController {
 
     @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API(이미지는 강아지 상태에 따른 아이템 단일 이미지로, 레이어드 할 투명 배경 이미지입니다)")
     @PostMapping("/{categoryId}/items/{itemId}/equip")
-    public ApiResponse<Map<String, Object>> equipItem(@PathVariable Long categoryId,
+    public ApiResponse<EquippedItemInfoDTO> equipItem(@PathVariable Long categoryId,
                                                       @PathVariable Long itemId) {
         Long userId = userAuthService.getCurrentUserId();
 
-        Map<String, Object> result = puppyItemService.equipItem(categoryId, itemId, userId);
+        EquippedItemInfoDTO result = puppyItemService.equipItem(categoryId, itemId, userId);
         return new ApiResponse<>(true, "SUCCESS_EQUIP_PUPPY_ITEM", "아이템 착용 성공", result);
     }
 
     @Operation(summary = "아이템 착용 해제 API", description = "강아지가 착용한 아이템을 해제하는 API")
     @PatchMapping("/{categoryId}/items/{itemId}/unequip")
-    public ResponseEntity<?> unequipItem(@PathVariable Long categoryId,
+    public ApiResponse<EquippedItemInfoDTO> unequipItem(@PathVariable Long categoryId,
                                          @PathVariable Long itemId) {
         Long userId = userAuthService.getCurrentUserId();
 
-        Map<String, Object> result = puppyItemService.unequipItem(categoryId, itemId, userId);
-        return ResponseEntity.ok(new ApiResponse<>(true, "SUCCESS_UNEQUIP_PUPPY_ITEM", "아이템 착용 해제 성공", result));
+        EquippedItemInfoDTO result = puppyItemService.unequipItem(categoryId, itemId, userId);
+        return new ApiResponse<>(true, "SUCCESS_UNEQUIP_PUPPY_ITEM", "아이템 착용 해제 성공", result);
     }
 
     @Operation(summary = "포인트 조회 API", description = "유저의 현재 포인트를 조회하는 API")
@@ -100,6 +101,19 @@ public class PuppyItemController {
                 true,
                 "SUCCESS_GET_OWNED_ITEMS",
                 "소유한 아이템 목록 조회 성공",
+                result);
+    }
+
+    @Operation(summary = "착용한 아이템 목록 조회 API", description = "강아지가 착용한 아이템 목록을 조회하는 API")
+    @GetMapping("/items/equip")
+    public ApiResponse<List<EquippedItemInfoDTO>> getEquippedItems() {
+        Long userId = userAuthService.getCurrentUserId();
+        List<EquippedItemInfoDTO> result = puppyItemService.getEquippedItems(userId);
+
+        return new ApiResponse<>(
+                true,
+                "SUCCESS_GET_EQUIP_ITEMS",
+                "착용한 아이템 목록 조회 성공",
                 result);
     }
 

--- a/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/EquippedItemInfoDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/PuppyCustomDTO/EquippedItemInfoDTO.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class EquippedItemInfoDTO {
     private Long itemId;
     private String itemName;
+    private String equippedImage;
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
강아지가 현재 착용한 아이템과 해당 아이템의 정보(아이디, 이름, 착용 아이템 이미지) 목록을 조회하는 API를 구현하였습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #116

## ⏳ 작업 내용
- 착용 아이템 목록 조회 API 구현

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
