### PR TITLE
[REFACTOR] 아이템 착용 관련 로직 수정 #119

### DIFF
--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyItemServiceImpl.java
@@ -166,12 +166,11 @@ public class PuppyItemServiceImpl implements PuppyItemService {
         PuppyCustomization customization = puppyCustomizationRepository.findByPuppyAndPuppyItem(puppy, item)
                 .orElseThrow(() -> new IllegalArgumentException("구매하지 않은 아이템입니다."));
 
-        // 같은 카테고리에서 현재 착용 중인 아이템 해제
-        PuppyCustomization currentEquippedItem = puppyCustomizationRepository.findByPuppyAndPuppyItemCategoryAndIsEquippedTrue(puppy, puppyItemCategory)
-                .orElse(null);
-        if (currentEquippedItem != null) {
-            currentEquippedItem.setIsEquipped(false);
-            puppyCustomizationRepository.save(currentEquippedItem);
+        // 착용 중인 아이템 해제
+        List<PuppyCustomization> equippedItems = puppyCustomizationRepository.findByPuppyAndIsEquippedTrue(puppy);
+        for (PuppyCustomization equippedItem : equippedItems) {
+            equippedItem.setIsEquipped(false);
+            puppyCustomizationRepository.save(equippedItem);
         }
 
         // 아이템 착용 처리
@@ -186,6 +185,10 @@ public class PuppyItemServiceImpl implements PuppyItemService {
                 itemId
         ).map(EquippedItemImage::getImageUrl)
                 .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
+
+        // 착용한 이미지를 강아지의 이미지 필드에 업데이트
+        puppy.setImageUrl(equippedImage);
+        puppyRepository.save(puppy);
 
         return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), equippedImage);
     }
@@ -224,15 +227,12 @@ public class PuppyItemServiceImpl implements PuppyItemService {
             throw new IllegalArgumentException("이미 착용하지 않은 아이템입니다.");
         }
 
-        // 아이템 착용 이미지
-        String equippedImage = equippedItemImageRepository.findByPuppyTypeAndLevelNameAndItemId(
-                        puppy.getPuppyLevel().getPuppyType(),
-                        puppy.getPuppyLevel().getLevelName(),
-                        itemId
-                ).map(EquippedItemImage::getImageUrl)
-                .orElseThrow(() -> new IllegalArgumentException("착용 이미지가 존재하지 않습니다."));
+        // 아이템 착용 해제 이미지
+        String unEquippedImage = puppy.getPuppyLevel().getLevelImageUrl();
+        puppy.setImageUrl(unEquippedImage);
+        puppyRepository.save(puppy);
 
-        return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), equippedImage);
+        return new EquippedItemInfoDTO(item.getItemId(), item.getItemName(), unEquippedImage);
     }
 
     @Override

--- a/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyItemController.java
@@ -60,7 +60,7 @@ public class PuppyItemController {
         );
     }
 
-    @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API(이미지는 강아지 상태에 따른 아이템 단일 이미지로, 레이어드 할 투명 배경 이미지입니다)")
+    @Operation(summary = "아이템 착용 API", description = "강아지에게 아이템을 착용시키는 API(중복 착용 불가)")
     @PostMapping("/{categoryId}/items/{itemId}/equip")
     public ApiResponse<EquippedItemInfoDTO> equipItem(@PathVariable Long categoryId,
                                                       @PathVariable Long itemId) {


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
아이템 착용 관련 로직 수정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #119

## ⏳ 작업 내용
- 아이템 카테고리 별 중복 착용 불가에서 모든 아이템 중복 착용 불가로 변경
- 아이템 착용 시 강아지 테이블 이미지 업데이트
- 아이템 착용 해제 시 강아지 테이블 이미지 업데이트

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
