### PR TITLE
Feat/#125 ranking friends

### DIFF
--- a/src/main/java/umc/puppymode/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/umc/puppymode/config/security/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         try {
             final String token = getJwtFromRequest(request);
-            log.info("Extracted JWT: {}", token);
+//            log.info("Extracted JWT: {}", token);
             if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
                 Long userId = jwtTokenProvider.getUserFromJwt(token);
                 // authentication 객체 생성 -> principal에 유저정보를 담는다.
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception exception) {
-            log.error("JWT processing error: {}", exception.getMessage());
+//            log.error("JWT processing error: {}", exception.getMessage());
             try {
                 throw new Exception();
             } catch (Exception e) {
@@ -50,11 +50,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        log.info("Authorization Header: {}", bearerToken);
+//        log.info("Authorization Header: {}", bearerToken);
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             String token = bearerToken.substring("Bearer ".length());
-            log.info("Extracted JWT from request: {}", token);
+//            log.info("Extracted JWT from request: {}", token);
             return token;
         }
 

--- a/src/main/java/umc/puppymode/repository/UserAuthRepository.java
+++ b/src/main/java/umc/puppymode/repository/UserAuthRepository.java
@@ -1,6 +1,7 @@
 package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.puppymode.domain.User;
@@ -19,4 +20,12 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
 
     @Query("SELECT u.user FROM UserAuth u WHERE u.authProvider = :authProvider AND u.authId IN :authIds")
     List<User> findUsersByAuthProviderAndAuthIdIn(@Param("authProvider") AuthProvider authProvider, @Param("authIds") List<String> authIds);
+
+    @Query("SELECT u.refreshToken FROM UserAuth u WHERE u.user.userId = :userId")
+    Optional<String> findRefreshTokenByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("UPDATE UserAuth u SET u.refreshToken = :refreshToken WHERE u.user.userId = :userId")
+    void updateRefreshToken(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);
+
 }

--- a/src/main/java/umc/puppymode/service/AuthService/KakaoAuthService.java
+++ b/src/main/java/umc/puppymode/service/AuthService/KakaoAuthService.java
@@ -1,15 +1,20 @@
 package umc.puppymode.service.AuthService;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import umc.puppymode.domain.enums.AuthProvider;
+import umc.puppymode.repository.UserAuthRepository;
 import umc.puppymode.web.dto.KakaoFriendsResponseDTO;
+import umc.puppymode.web.dto.KakaoTokenResponseDTO;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 import umc.puppymode.web.dto.UserAuthInfoDTO;
 
@@ -20,7 +25,14 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
-    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    private static final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+    private static final String KAUTH_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private final UserAuthRepository userAuthRepository;
+    private final WebClient webClient = WebClient.create(KAUTH_USER_URL_HOST);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${kakao.client_id}")
+    private String kakaoClientId;
 
     /**
      * 카카오 회원의 정보를 가져옵니다.
@@ -29,20 +41,7 @@ public class KakaoAuthService {
      * @return 회원 정보 전체
      */
     public UserAuthInfoDTO getUserInfo(String accessToken) {
-
-        KakaoUserInfoResponseDTO userInfo = WebClient.create(KAUTH_USER_URL_HOST)
-                .get()
-                .uri(uriBuilder -> uriBuilder
-                        .scheme("https")
-                        .path("/v2/user/me")
-                        .build(true))
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
-                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse -> Mono.error(new RuntimeException("Invalid Parameter")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse -> Mono.error(new RuntimeException("Internal Server Error")))
-                .bodyToMono(KakaoUserInfoResponseDTO.class)
-                .block();
+        KakaoUserInfoResponseDTO userInfo = requestKakaoAPI("/v2/user/me", accessToken, KakaoUserInfoResponseDTO.class);
 
 //        log.info("[ Kakao Service ] Auth ID —> {} ", userInfo.getId());
 //        log.info("[ Kakao Service ] NickName —> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
@@ -51,7 +50,7 @@ public class KakaoAuthService {
         validateKakaoUserInfo(userInfo);
 
         return UserAuthInfoDTO.builder()
-                .userAuthId(userInfo.getId().toString())  // 카카오 고유 ID
+                .userAuthId(userInfo.getId().toString())
                 .email(userInfo.getKakaoAccount().getEmail())
                 .username(userInfo.getKakaoAccount().getProfile().getNickName())
                 .authProvider(AuthProvider.KAKAO)
@@ -59,27 +58,68 @@ public class KakaoAuthService {
     }
 
     /**
-     * 카카오 친구 목록을 가져옵니다.
-     *
-     * @param accessToken
-     * @return 친구들의 authId 목록
+     * 카카오 친구 목록을 가져옵니다. (토큰 만료 시 자동 갱신)
      */
-    public List<String> getFriendsList(String accessToken) {
+    public List<String> getFriendsList(String accessToken, Long userId) {
+        try {
+            return requestFriendsList(accessToken);
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("401")) {  // 만료 처리
+                log.warn("[Kakao Service] Access token expired or invalid. Refreshing...");
+                try {
+                    String newAccessToken = refreshAccessToken(userId); // access Token 재발급
+                    return requestFriendsList(newAccessToken);
+                } catch (RuntimeException refreshException) {
+                    log.error("[Kakao Service] Failed to refresh access token. Re-login required.");
+                    throw new RuntimeException("카카오 친구 목록을 가져올 수 없습니다. 재로그인이 필요합니다.", refreshException);
+                }
+            }
+            throw e;
+        }
+    }
 
-        KakaoFriendsResponseDTO friendsResponse = WebClient.create(KAUTH_USER_URL_HOST)
-                .get()
-                .uri("/v1/api/talk/friends")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
-                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+    /**
+     * refreshToken을 사용하여 새로운 accessToken을 발급합니다.
+     */
+    public String refreshAccessToken(Long userId) {
+        String refreshToken = userAuthRepository.findRefreshTokenByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Refresh token not found"));
+
+        KakaoTokenResponseDTO tokenResponse = WebClient.create(KAUTH_TOKEN_URL)
+                .post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("grant_type", "refresh_token")
+                        .queryParam("client_id", kakaoClientId)
+                        .queryParam("refresh_token", refreshToken)
+                        .build())
                 .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
-                        Mono.error(new RuntimeException("카카오 친구 목록을 가져오는 요청이 잘못되었습니다.")))
-                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
-                        Mono.error(new RuntimeException("카카오 서버 오류")))
-                .bodyToMono(KakaoFriendsResponseDTO.class)
+                .bodyToMono(KakaoTokenResponseDTO.class)
                 .block();
 
-        log.info("[ Kakao Service ] 친구 목록 응답: {}", friendsResponse); //Todo: comment
+        if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+            throw new RuntimeException("Failed to refresh Kakao access token");
+        }
+
+        if (tokenResponse.getRefreshToken() != null) {
+            updateRefreshTokenInDB(userId, tokenResponse.getRefreshToken());
+        }
+
+        return tokenResponse.getAccessToken();
+    }
+
+    /**
+     * user_auth 테이블의 refreshToken을 업데이트합니다.
+     */
+    private void updateRefreshTokenInDB(Long userId, String newRefreshToken) {
+        userAuthRepository.updateRefreshToken(userId, newRefreshToken);
+        log.info("[Kakao Service] Refresh token updated");
+    }
+
+    /**
+     * requestKakaoAPI를 통해 친구 목록을 가져옵니다.
+     */
+    private List<String> requestFriendsList(String accessToken) {
+        KakaoFriendsResponseDTO friendsResponse = requestKakaoAPI("/v1/api/talk/friends", accessToken, KakaoFriendsResponseDTO.class);
 
         if (friendsResponse == null || friendsResponse.getElements() == null) {
             throw new IllegalArgumentException("카카오 친구 목록을 가져올 수 없습니다.");
@@ -89,6 +129,41 @@ public class KakaoAuthService {
                 .map(KakaoFriendsResponseDTO.Friend::getId)
                 .map(String::valueOf)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 공통 API 요청 메서드
+     */
+    private <T> T requestKakaoAPI(String path, String accessToken, Class<T> responseType) {
+        T response = webClient.get()
+                .uri(path)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        clientResponse.bodyToMono(String.class).flatMap(error -> {
+                            log.error("[Kakao Service] 4XX Error: {}", error);
+                            handleKakaoApiError(error);
+                            return Mono.error(new RuntimeException("카카오 API 요청 실패: " + error));
+                        }))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new RuntimeException("카카오 서버 오류")))
+                .bodyToMono(responseType)
+                .block();
+
+//        logResponse(response);
+        return response;
+    }
+
+    /**
+     * 응답 데이터를 JSON으로 변환하여 로그를 출력합니다.
+     */
+    private void logResponse(Object response) {
+        try {
+            log.info("[ Kakao Service ] 응답: {}", objectMapper.writeValueAsString(response));
+        } catch (JsonProcessingException e) {
+            log.error("[ Kakao Service ] JSON 변환 실패", e);
+        }
     }
 
     /**
@@ -111,5 +186,21 @@ public class KakaoAuthService {
         if (userInfo.getKakaoAccount().getEmail() == null) {
             throw new IllegalArgumentException("카카오 이메일 정보가 존재하지 않습니다.");
         }
+    }
+
+    /**
+     * 예외 처리
+     */
+    private void handleKakaoApiError(String errorResponse) {
+        if (errorResponse.contains("\"code\": -401")) {
+            throw new IllegalArgumentException("잘못된 Access Token입니다. 재로그인이 필요합니다.");
+        }
+        if (errorResponse.contains("\"code\": -402")) {
+            throw new IllegalStateException("카카오 API 사용량 초과. 잠시 후 다시 시도하세요.");
+        }
+        if (errorResponse.contains("\"code\": -500")) {
+            throw new RuntimeException("카카오 서버 내부 오류 발생. 나중에 다시 시도해주세요.");
+        }
+        throw new RuntimeException("카카오 API 요청 실패: " + errorResponse);
     }
 }

--- a/src/main/java/umc/puppymode/service/AuthService/KakaoAuthService.java
+++ b/src/main/java/umc/puppymode/service/AuthService/KakaoAuthService.java
@@ -9,8 +9,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import umc.puppymode.domain.enums.AuthProvider;
+import umc.puppymode.web.dto.KakaoFriendsResponseDTO;
 import umc.puppymode.web.dto.KakaoUserInfoResponseDTO;
 import umc.puppymode.web.dto.UserAuthInfoDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -52,6 +56,39 @@ public class KakaoAuthService {
                 .username(userInfo.getKakaoAccount().getProfile().getNickName())
                 .authProvider(AuthProvider.KAKAO)
                 .build();
+    }
+
+    /**
+     * 카카오 친구 목록을 가져옵니다.
+     *
+     * @param accessToken
+     * @return 친구들의 authId 목록
+     */
+    public List<String> getFriendsList(String accessToken) {
+
+        KakaoFriendsResponseDTO friendsResponse = WebClient.create(KAUTH_USER_URL_HOST)
+                .get()
+                .uri("/v1/api/talk/friends")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken) // access token 인가
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new RuntimeException("카카오 친구 목록을 가져오는 요청이 잘못되었습니다.")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new RuntimeException("카카오 서버 오류")))
+                .bodyToMono(KakaoFriendsResponseDTO.class)
+                .block();
+
+        log.info("[ Kakao Service ] 친구 목록 응답: {}", friendsResponse); //Todo: comment
+
+        if (friendsResponse == null || friendsResponse.getElements() == null) {
+            throw new IllegalArgumentException("카카오 친구 목록을 가져올 수 없습니다.");
+        }
+
+        return friendsResponse.getElements().stream()
+                .map(KakaoFriendsResponseDTO.Friend::getId)
+                .map(String::valueOf)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
@@ -107,7 +107,6 @@ public class UserAuthServiceImpl implements UserAuthService {
         LoginResponseDTO.LoginUserInfo loginUserInfo = LoginResponseDTO.LoginUserInfo.builder()
                 .userId(user.getUserId())
                 .username(user.getUsername())
-                .email(user.getEmail())
                 .isNewUser(isNewUser)
                 .build();
 

--- a/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
@@ -1,6 +1,7 @@
 package umc.puppymode.service.AuthService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ import umc.puppymode.web.dto.UserAuthInfoDTO;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -44,14 +46,27 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         Optional<UserAuth> optionalUserAuth = userAuthRepository.findByUser_EmailAndAuthProvider(email, authProvider);
 
+        UserAuth userAuth;
+        User user;
+
         if (optionalUserAuth.isPresent()) {
-            User existingUser = optionalUserAuth.get().getUser();
-            return generateLoginResponse(existingUser, false);
+            // 기존 회원일 경우
+            userAuth = optionalUserAuth.get();
+            user = userAuth.getUser();
+
+            // Refresh Token 갱신 필요 확인
+            if (refreshToken != null && !refreshToken.equals(userAuth.getRefreshToken())) {
+                log.info("Refresh Token 갱신됨.");
+                userAuth.setRefreshToken(refreshToken);
+                userAuthRepository.save(userAuth);
+            }
+
+            return generateLoginResponse(user, false);
         }
 
         Optional<User> optionalUser = userRepository.findByEmail(email);
 
-        User user = optionalUser.map(existingUser -> {
+        user = optionalUser.map(existingUser -> {
             if (existingUser.getIsDeleted()) {
                 // 탈퇴한 사용자 복구
                 existingUser.setIsDeleted(false);
@@ -71,7 +86,7 @@ public class UserAuthServiceImpl implements UserAuthService {
             return userRepository.save(newUser);
         });
 
-        UserAuth userAuth = UserAuth.builder()
+        userAuth = UserAuth.builder()
                 .user(user)
                 .authProvider(authProvider)
                 .authId(authId)

--- a/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/UserAuthServiceImpl.java
@@ -55,7 +55,7 @@ public class UserAuthServiceImpl implements UserAuthService {
             user = userAuth.getUser();
 
             // Refresh Token 갱신 필요 확인
-            if (refreshToken != null && !refreshToken.equals(userAuth.getRefreshToken())) {
+            if (refreshToken != null && (userAuth.getRefreshToken() == null || !refreshToken.equals(userAuth.getRefreshToken()))) {
                 log.info("Refresh Token 갱신됨.");
                 userAuth.setRefreshToken(refreshToken);
                 userAuthRepository.save(userAuth);

--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryService.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryService.java
@@ -2,11 +2,9 @@ package umc.puppymode.service.RankingService;
 
 import umc.puppymode.web.dto.RankingResponseDTO;
 
-import java.util.List;
-
 public interface RankingQueryService {
     // 친구 랭킹 조회하기
-    RankingResponseDTO getFriendRankings(List<String> authIds, int page, int size, Long currentUserId);
+    RankingResponseDTO getFriendRankings(String accessToken, int page, int size, Long currentUserId);
 
     // 전체 랭킹 조회하기
     RankingResponseDTO getGlobalRankings(int page, int size, Long currentUserId);

--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
@@ -7,6 +7,7 @@ import umc.puppymode.domain.User;
 import umc.puppymode.domain.enums.AuthProvider;
 import umc.puppymode.repository.PuppyRepository;
 import umc.puppymode.repository.UserAuthRepository;
+import umc.puppymode.service.AuthService.KakaoAuthService;
 import umc.puppymode.web.dto.RankingDTO;
 import umc.puppymode.web.dto.RankingResponseDTO;
 
@@ -22,12 +23,14 @@ public class RankingQueryServiceImpl implements RankingQueryService {
 
     private final UserAuthRepository userAuthProviderRepository;
     private final PuppyRepository puppyRepository;
+    private final KakaoAuthService kakaoAuthService;
 
     /**
      * 친구 목록(authIds)중, 가입된 회원들의 강아지 정보를 가져와 랭킹을 조회합니다.
      */
     @Override
-    public RankingResponseDTO getFriendRankings(List<String> authIds, int page, int size, Long currentUserId) {
+    public RankingResponseDTO getFriendRankings(String accessToken, int page, int size, Long currentUserId) {
+        List<String> authIds = kakaoAuthService.getFriendsList(accessToken);
         String currentUserAuthId = userAuthProviderRepository.findAuthIdByUserId(currentUserId).orElse(null);
         authIds.add(currentUserAuthId);
         List<User> kakaoUsers = userAuthProviderRepository.findUsersByAuthProviderAndAuthIdIn(AuthProvider.KAKAO, authIds);

--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
@@ -30,7 +30,7 @@ public class RankingQueryServiceImpl implements RankingQueryService {
      */
     @Override
     public RankingResponseDTO getFriendRankings(String accessToken, int page, int size, Long currentUserId) {
-        List<String> authIds = kakaoAuthService.getFriendsList(accessToken);
+        List<String> authIds = kakaoAuthService.getFriendsList(accessToken, currentUserId);
         String currentUserAuthId = userAuthProviderRepository.findAuthIdByUserId(currentUserId).orElse(null);
         authIds.add(currentUserAuthId);
         List<User> kakaoUsers = userAuthProviderRepository.findUsersByAuthProviderAndAuthIdIn(AuthProvider.KAKAO, authIds);

--- a/src/main/java/umc/puppymode/service/UserService/UserInfoServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/UserService/UserInfoServiceImpl.java
@@ -33,9 +33,7 @@ public class UserInfoServiceImpl implements UserInfoService {
                 .build();
 
         return UserInfoResponseDTO.builder()
-                .userId(user.getUserId())
                 .username(user.getUsername())
-                .email(user.getEmail())
                 .puppy(userPuppyInfo)
                 .build();
     }

--- a/src/main/java/umc/puppymode/web/controller/KakaoAuthController.java
+++ b/src/main/java/umc/puppymode/web/controller/KakaoAuthController.java
@@ -33,7 +33,7 @@ public class KakaoAuthController {
                     "`FCMToken`을 함께 전송하여 푸시 알림을 위한 토큰을 저장합니다.")
     public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
             @RequestParam("accessToken") String accessToken,
-            @RequestParam(value = "refreshToken", required = false) String refreshToken,
+            @RequestParam(value = "refreshToken") String refreshToken,
             @RequestParam(value = "FCMToken", required = false) String fcmToken) {
         try {
             UserAuthInfoDTO userInfo = kakaoAuthService.getUserInfo(accessToken);

--- a/src/main/java/umc/puppymode/web/controller/RankingController.java
+++ b/src/main/java/umc/puppymode/web/controller/RankingController.java
@@ -1,6 +1,5 @@
 package umc.puppymode.web.controller;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -11,8 +10,6 @@ import umc.puppymode.service.RankingService.RankingQueryService;
 import umc.puppymode.service.AuthService.UserAuthService;
 import umc.puppymode.web.dto.RankingResponseDTO;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rankings")
@@ -21,12 +18,11 @@ public class RankingController {
     private final RankingQueryService rankingQueryService;
     private final UserAuthService userAuthService;
 
-    @Hidden
-//    @GetMapping("/friends")
+    @GetMapping("/friends")
     @Operation(summary = "카카오 친구 랭킹 조회 API", description = "친구인 사용자 랭킹을 조회하는 API입니다.")
     public ResponseEntity<ApiResponse<RankingResponseDTO>> getFriendRankings(
-            @Parameter(description = "Kakao 친구 Id 목록 (개별 입력)", example = "authIds=123456&authIds=654321")
-            @RequestParam List<String> authIds,
+            @Parameter(description = "Kakao Access Token")
+            @RequestParam String accessToken,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
             @RequestParam int page,
             @Parameter(description = "한 페이지당 데이터 수", example = "10")
@@ -34,7 +30,7 @@ public class RankingController {
 
         Long userId = userAuthService.getCurrentUserId();
 
-        RankingResponseDTO responseDTO = rankingQueryService.getFriendRankings(authIds, page, size, userId);
+        RankingResponseDTO responseDTO = rankingQueryService.getFriendRankings(accessToken, page, size, userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(responseDTO));
     }

--- a/src/main/java/umc/puppymode/web/dto/KakaoFriendsResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/KakaoFriendsResponseDTO.java
@@ -1,0 +1,28 @@
+package umc.puppymode.web.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class KakaoFriendsResponseDTO {
+
+    private List<Friend> elements; // 친구 목록 배열
+    private int total_count; // 전체 친구 수
+    private int favorite_count; // 즐겨찾기한 친구 수
+
+    @Getter
+    @NoArgsConstructor
+    @ToString
+    public static class Friend {
+        private Long id; // authId
+        private String uuid;
+        private boolean favorite;
+        private String profile_nickname;
+        private String profile_thumbnail_image;
+    }
+}

--- a/src/main/java/umc/puppymode/web/dto/LoginResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/LoginResponseDTO.java
@@ -1,5 +1,6 @@
 package umc.puppymode.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +19,9 @@ public class LoginResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class LoginUserInfo {
+        @JsonIgnore
         private Long userId;
-        private String email;
+
         private String username;
         private Boolean isNewUser;
     }

--- a/src/main/java/umc/puppymode/web/dto/UserInfoResponseDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/UserInfoResponseDTO.java
@@ -10,9 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserInfoResponseDTO {
-    private Long userId;
     private String username;
-    private String email;
     private UserPuppyInfo puppy;
 
     @Getter


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
친구 랭킹 구현

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #125

## ⏳ 작업 내용
- 서버에서 카카오 친구 목록 불러오기 구현
    - 클라이언트로부터 `AccessToken`을 받음
    - 만료된 경우 `RefreshToken`으로 재발급
    클라이언트에서 `AccessToken` 관리하는것이 적합함 (로그인 시 직접 받음)
- `KakaoAuthService` 리팩토링
- 카카오 refresh token 자동 갱신 구현

### 📝 논의사항
- **재로그인 필요합니다.**
- 추후 친구 목록 호출 시 페이징 필요