### PR TITLE
Bug/#130 ranking diff

### DIFF
--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
@@ -66,8 +66,8 @@ public class RankingQueryServiceImpl implements RankingQueryService {
     }
 
     /**
-     * puppy list를 puppyExp 기준으로 정렬하고, 랭킹을 계산합니다.
-     * 동일 경험치인 경우 공동 순위 처리합니다.
+     * puppy list를 puppyExp 기준으로 정렬하고,
+     * 동일 경험치인 경우 updated_at 기준으로 정렬하여 랭킹을 계산합니다.
      *
      * @param puppies 랭킹 계산할 강아지 리스트
      * @return 경험치 기준으로 정렬된 강아지 랭킹 리스트
@@ -78,7 +78,11 @@ public class RankingQueryServiceImpl implements RankingQueryService {
         AtomicReference<Integer> previousRank = new AtomicReference<>(0);
 
         return puppies.stream()
-                .sorted(Comparator.comparingInt(Puppy::getPuppyExp).reversed())
+                .sorted(Comparator
+                        .comparingInt(Puppy::getPuppyExp).reversed()
+                        .thenComparing(Puppy::getUpdatedAt)
+                        .thenComparing(puppy -> puppy.getUser().getUserId())
+                )
                 .map(puppy -> {
                     if (previousExp.get() != null && puppy.getPuppyExp().equals(previousExp.get())) {
                         return RankingDTO.from(puppy, previousRank.get());

--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
@@ -74,8 +74,6 @@ public class RankingQueryServiceImpl implements RankingQueryService {
      */
     private List<RankingDTO> calculateRankings(List<Puppy> puppies) {
         AtomicInteger rankCounter = new AtomicInteger(1);
-        AtomicReference<Integer> previousExp = new AtomicReference<>(null);
-        AtomicReference<Integer> previousRank = new AtomicReference<>(0);
 
         return puppies.stream()
                 .sorted(Comparator
@@ -83,15 +81,7 @@ public class RankingQueryServiceImpl implements RankingQueryService {
                         .thenComparing(Puppy::getUpdatedAt)
                         .thenComparing(puppy -> puppy.getUser().getUserId())
                 )
-                .map(puppy -> {
-                    if (previousExp.get() != null && puppy.getPuppyExp().equals(previousExp.get())) {
-                        return RankingDTO.from(puppy, previousRank.get());
-                    } else {
-                        previousExp.set(puppy.getPuppyExp());
-                        previousRank.set(rankCounter.getAndIncrement());
-                        return RankingDTO.from(puppy, previousRank.get());
-                    }
-                })
+                .map(puppy -> RankingDTO.from(puppy, rankCounter.getAndIncrement()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/RankingService/RankingQueryServiceImpl.java
@@ -14,7 +14,6 @@ import umc.puppymode.web.dto.RankingResponseDTO;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Service


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
랭킹 계산 로직 수정
경험치 같으면 공동순위 -> 항상 차등 순위로 수정

동일 경험치 -> puppy의 update 시간으로 정렬
update time도 같은 경우 user_id 순으로 정렬.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #130

## ⏳ 작업 내용
- `RankingQueryService`의 `calculateRankings` 수정