### PR TITLE
[FEAT] 애니메이션 프레임 조회 API 수정 #132

### DIFF
--- a/src/main/java/umc/puppymode/PuppymodeApplication.java
+++ b/src/main/java/umc/puppymode/PuppymodeApplication.java
@@ -15,3 +15,4 @@ public class PuppymodeApplication {
 	}
 
 }
+git

--- a/src/main/java/umc/puppymode/domain/PuppyAnimation.java
+++ b/src/main/java/umc/puppymode/domain/PuppyAnimation.java
@@ -28,6 +28,10 @@ public class PuppyAnimation {
 
     private String levelName; // 강아지 레벨 이름
 
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private PuppyItem item; // 착용 아이템
+
     @OneToMany(mappedBy = "animation", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PuppyAnimationImage> animationImages; // 애니메이션 이미지 리스트
 }

--- a/src/main/java/umc/puppymode/domain/enums/AnimationType.java
+++ b/src/main/java/umc/puppymode/domain/enums/AnimationType.java
@@ -1,5 +1,7 @@
 package umc.puppymode.domain.enums;
 
 public enum AnimationType {
-    PLAYING // 놀아주기
+    PLAYING, // 놀아주기
+    FEEDING, // 먹이주기
+    DRINKING // 음주 중
 }

--- a/src/main/java/umc/puppymode/repository/PuppyAnimationRepository.java
+++ b/src/main/java/umc/puppymode/repository/PuppyAnimationRepository.java
@@ -2,6 +2,7 @@ package umc.puppymode.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.puppymode.domain.PuppyAnimation;
+import umc.puppymode.domain.PuppyItem;
 import umc.puppymode.domain.enums.AnimationType;
 import umc.puppymode.domain.enums.PuppyType;
 
@@ -9,4 +10,6 @@ import java.util.Optional;
 
 public interface PuppyAnimationRepository extends JpaRepository<PuppyAnimation, Long> {
     Optional<PuppyAnimation> findByAnimationTypeAndPuppyTypeAndLevelName(AnimationType animationType, PuppyType puppyType, String levelName);
+    Optional<PuppyAnimation> findByAnimationTypeAndPuppyTypeAndLevelNameAndItem(
+            AnimationType animationType, PuppyType puppyType, String levelName, PuppyItem item);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationService.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationService.java
@@ -4,5 +4,5 @@ import umc.puppymode.domain.enums.AnimationType;
 import umc.puppymode.web.dto.AnimationFramesResponseDTO;
 
 public interface PuppyAnimationService {
-    AnimationFramesResponseDTO getAnimaitonFrames(AnimationType animationType, Long userId);
+    AnimationFramesResponseDTO getAnimationFrames(AnimationType animationType, Long userId);
 }

--- a/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/PuppyService/PuppyAnimationServiceImpl.java
@@ -7,8 +7,11 @@ import umc.puppymode.apiPayload.exception.GeneralException;
 import umc.puppymode.domain.Puppy;
 import umc.puppymode.domain.PuppyAnimation;
 import umc.puppymode.domain.PuppyAnimationImage;
+import umc.puppymode.domain.PuppyItem;
 import umc.puppymode.domain.enums.AnimationType;
+import umc.puppymode.domain.mapping.PuppyCustomization;
 import umc.puppymode.repository.PuppyAnimationRepository;
+import umc.puppymode.repository.PuppyCustomizationRepository;
 import umc.puppymode.repository.PuppyRepository;
 import umc.puppymode.web.dto.AnimationFramesResponseDTO;
 
@@ -22,21 +25,33 @@ public class PuppyAnimationServiceImpl implements PuppyAnimationService{
 
     private final PuppyAnimationRepository puppyAnimationRepository;
     private final PuppyRepository puppyRepository;
+    private final PuppyCustomizationRepository puppyCustomizationRepository;
 
     @Override
-    public AnimationFramesResponseDTO getAnimaitonFrames(AnimationType animationType, Long userId) {
+    public AnimationFramesResponseDTO getAnimationFrames(AnimationType animationType, Long userId) {
 
-        // 유저의 강아지 찾기
         // 유저의 강아지 찾기
         Puppy puppy = puppyRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NO_USERS_PUPPY));
 
+        // 현재 착용 중인 아이템 찾기
+        List<PuppyCustomization> equippedItems = puppyCustomizationRepository.findByPuppyAndIsEquippedTrue(puppy);
+        PuppyItem equippedItem = equippedItems.isEmpty() ? null : equippedItems.get(0).getPuppyItem();
+
         // 해당하는 애니메이션 찾기
-        PuppyAnimation puppyAnimation = puppyAnimationRepository.findByAnimationTypeAndPuppyTypeAndLevelName(
-                        animationType,
-                        puppy.getPuppyLevel().getPuppyType(),
-                        puppy.getPuppyLevel().getLevelName()
-                ).orElseThrow(() -> new GeneralException(ErrorStatus.ANIMATION_NOT_FOUND));
+        PuppyAnimation puppyAnimation;
+        if (animationType == AnimationType.DRINKING) {  // 음주 중 애니메이션의 경우, 아이템 고려 X
+            puppyAnimation = puppyAnimationRepository.findByAnimationTypeAndPuppyTypeAndLevelName(
+                    animationType, puppy.getPuppyLevel().getPuppyType(), puppy.getPuppyLevel().getLevelName()
+            ).orElseThrow(() -> new GeneralException(ErrorStatus.ANIMATION_NOT_FOUND));
+        }
+        else {
+            puppyAnimation = puppyAnimationRepository.findByAnimationTypeAndPuppyTypeAndLevelNameAndItem(
+                            animationType, puppy.getPuppyLevel().getPuppyType(), puppy.getPuppyLevel().getLevelName(), equippedItem)
+                    .or(() -> puppyAnimationRepository.findByAnimationTypeAndPuppyTypeAndLevelName(
+                            animationType, puppy.getPuppyLevel().getPuppyType(), puppy.getPuppyLevel().getLevelName()))
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.ANIMATION_NOT_FOUND));
+        }
 
         // 애니메이션 프레임 가져오기
         List<PuppyAnimationImage> animationImages = puppyAnimation.getAnimationImages();

--- a/src/main/java/umc/puppymode/web/controller/PuppyAnimationController.java
+++ b/src/main/java/umc/puppymode/web/controller/PuppyAnimationController.java
@@ -25,7 +25,7 @@ public class PuppyAnimationController {
     public ApiResponse<AnimationFramesResponseDTO> getAnimationFrames(
             @RequestParam AnimationType animationType) {
         Long userId = userAuthService.getCurrentUserId();
-        AnimationFramesResponseDTO animationFramesResponseDTO = puppyAnimationService.getAnimaitonFrames(animationType, userId);
+        AnimationFramesResponseDTO animationFramesResponseDTO = puppyAnimationService.getAnimationFrames(animationType, userId);
         return ApiResponse.onSuccess(animationFramesResponseDTO);
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
애니메이션 프레임 조회 시 아이템 고려하도록 수정(음주 중 애니메이션은 아이템 고려 X)

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #132

## ⏳ 작업 내용
- 애니메이션 프레임 조회 API 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
