### PR TITLE
[FEAT] 가장 가까운 SCHEDULED 상태의 약속 찾기 #137

### DIFF
--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -11,7 +11,6 @@ import umc.puppymode.domain.User;
 import umc.puppymode.domain.enums.AppointmentStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,4 +37,8 @@ public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingApp
             "WHERE da.user.userId = :userId " +
             "AND FUNCTION('DATE_FORMAT', da.dateTime, '%Y-%m') = :month")
     List<DrinkingAppointment> findAppointmentsByUserAndMonth(@Param("userId") Long userId, @Param("month") String month);
+
+    @Query("SELECT a FROM DrinkingAppointment a WHERE a.status = 'SCHEDULED' AND a.user.userId = :userId " +
+            "AND DATE(a.dateTime) = CURRENT_DATE ORDER BY a.dateTime ASC LIMIT 1")
+    Optional<DrinkingAppointment> findNearestScheduledAppointmentForToday(@Param("userId") Long userId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryService.java
@@ -3,9 +3,12 @@ package umc.puppymode.service.DrinkingAppointmentService;
 import umc.puppymode.domain.enums.AppointmentStatus;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 
+import java.util.Optional;
+
 public interface DrinkingAppointmentQueryService {
     DrinkingAppointmentResponseDTO.AppointmentResultDTO getDrinkingAppointmentById(Long appointmentId, Long userId);
     DrinkingAppointmentResponseDTO.AppointmentListResultDTO getAllDrinkingAppointments(AppointmentStatus status, int page, int size, Long userId);
     boolean isDrinkingActive(Long appointmentId, Long userId);
     int getDrinkingDuration(Long appointmentId, Long userId);
+    Optional<DrinkingAppointmentResponseDTO.AppointmentSimpleDTO> getNearestScheduledAppointmentForToday(Long userId);
 }

--- a/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/DrinkingAppointmentService/DrinkingAppointmentQueryServiceImpl.java
@@ -14,6 +14,7 @@ import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -110,5 +111,11 @@ public class DrinkingAppointmentQueryServiceImpl implements DrinkingAppointmentQ
 
         // 최소 1시간 이상 경과 시 반환, 1시간 미만이면 1시간으로 처리
         return Math.max(1, (int) drinkingHours);
+    }
+
+    @Override
+    public Optional<DrinkingAppointmentResponseDTO.AppointmentSimpleDTO> getNearestScheduledAppointmentForToday(Long userId) {
+        return drinkingAppointmentRepository.findNearestScheduledAppointmentForToday(userId)
+                .map(DrinkingAppointmentConverter::toSimpleDTO);
     }
 }

--- a/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
+++ b/src/main/java/umc/puppymode/web/controller/DrinkingAppointmentController.java
@@ -19,6 +19,8 @@ import umc.puppymode.web.dto.DrinkingAppointmentRequestDTO;
 import umc.puppymode.web.dto.DrinkingAppointmentResponseDTO;
 import umc.puppymode.web.dto.MainPuppyDTO.MainPuppyResDTO;
 
+import java.util.Optional;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -167,6 +169,21 @@ public class DrinkingAppointmentController {
 
         return ApiResponse.onSuccess(response, "APPOINTMENT_UPDATE_SUCCESS", "술 약속 수정 성공");
 
+    }
+
+    @GetMapping("/nearest-scheduled")
+    @Operation(summary = "오늘 날짜의 가장 가까운 SCHEDULED 상태 약속 조회",
+            description = "오늘 날짜의 가장 가까운 SCHEDULED 상태의 약속 정보를 반환합니다.")
+    public ApiResponse<?> getNearestScheduledAppointmentForToday() {
+        Long userId = userAuthService.getCurrentUserId();
+
+        Optional<DrinkingAppointmentResponseDTO.AppointmentSimpleDTO> response =
+                drinkingAppointmentQueryService.getNearestScheduledAppointmentForToday(userId);
+
+        return response.map(appointment ->
+                        ApiResponse.onSuccess(appointment, "APPOINTMENT_NEAREST_SCHEDULED_FOUND", "오늘 날짜의 가장 가까운 예약된 술 약속을 조회했습니다."))
+                .orElseGet(() ->
+                        ApiResponse.onFailure("NO_SCHEDULED_APPOINTMENT_TODAY", "오늘 날짜의 예약된 술 약속이 없습니다.", null));
     }
 
 }


### PR DESCRIPTION
# 🚀 개요
프론트 피드백에 따라 프론트에서 처리하기 번거로운 로직을 백에서 처리합니다.
가장 가까운 SCHEDULED 상태의 약속을 찾아 응답합니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #137 

## ⏳ 작업 내용
- 가장 가까운 SCHEDULED 상태의 약속 찾기 API 구현
