### PR TITLE
[REFACTOR] 가장 가까운 SCHEDULED 상태의 약속 조회하기 API 수정 #149

### DIFF
--- a/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
+++ b/src/main/java/umc/puppymode/repository/DrinkingAppointmentRepository.java
@@ -38,7 +38,16 @@ public interface DrinkingAppointmentRepository extends JpaRepository<DrinkingApp
             "AND FUNCTION('DATE_FORMAT', da.dateTime, '%Y-%m') = :month")
     List<DrinkingAppointment> findAppointmentsByUserAndMonth(@Param("userId") Long userId, @Param("month") String month);
 
-    @Query("SELECT a FROM DrinkingAppointment a WHERE a.status = 'SCHEDULED' AND a.user.userId = :userId " +
-            "AND DATE(a.dateTime) = CURRENT_DATE ORDER BY a.dateTime ASC LIMIT 1")
+    //MySQL만 지원
+    @Query(value = "SELECT * FROM drinking_appointment " +
+            "WHERE status = 'SCHEDULED' " +
+            "AND user_id = :userId " +
+            "AND date_time BETWEEN DATE(DATE_ADD(NOW(), INTERVAL 9 HOUR)) " +
+            "AND DATE_ADD(DATE(DATE_ADD(NOW(), INTERVAL 9 HOUR)), INTERVAL 1 DAY) - INTERVAL 1 SECOND " +
+            "ORDER BY date_time ASC " +
+            "LIMIT 1",
+            nativeQuery = true)
     Optional<DrinkingAppointment> findNearestScheduledAppointmentForToday(@Param("userId") Long userId);
+
+
 }


### PR DESCRIPTION
# 🚀 개요
SQL 서버 시간과 한국 시간(KST)이 일치하지 않아 음주 약속 조회 시 오류가 발생하는 문제가 있었습니다. 이를 고려하여 시간 변환 로직을 최적화하여 데이터 조회가 정확하게 이루어지도록 튜닝했습니다.

## 📌 관련 이슈번호
- Closes #149 

## ⏳ 작업 내용
- 가장 가까운 SCHEDULED 상태의 약속 조회하기 API 쿼리 튜닝