### PR TITLE
[CI] 애플 시크릿 키파일 로드 방식 변경 #156

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,11 +40,9 @@ jobs:
           mkdir -p ./src/main/resources/firebase
           echo "${{ secrets.FIREBASE_ADMIN_SDK_BASE64 }}" | base64 -d > ./src/main/resources/firebase/puppymode-53d9a-firebase-adminsdk-myzbc-7e65f856a6.json
 
-      # Apple Private Key 파일 생성
-      - name: Make Apple Private Key file
-        run: |
-          mkdir -p ~/.secrets
-          echo "${{ secrets.APPLE_PRIVATE_KEY_BASE64 }}" | base64 -d > ~/.secrets/AuthKey.p8
+      # Apple Private Key 파일 환경변수 load
+      - name: Set Apple Private Key as Environment Variable
+        run: echo "APPLE_PRIVATE_KEY=$(echo '${{ secrets.APPLE_PRIVATE_KEY_BASE64 }}' | base64 -d)" >> $GITHUB_ENV
         shell: bash
 
       # yml 파일 생성

--- a/src/main/java/umc/puppymode/config/AppleAuthConfig.java
+++ b/src/main/java/umc/puppymode/config/AppleAuthConfig.java
@@ -25,7 +25,4 @@ public class AppleAuthConfig {
 
     @Value("${auth.apple.key-id}")
     private String keyId;
-
-    @Value("${auth.apple.private-key-path}")
-    private String privateKeyPath;
 }

--- a/src/main/java/umc/puppymode/service/AuthService/AppleKeyServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleKeyServiceImpl.java
@@ -91,17 +91,20 @@ public class AppleKeyServiceImpl implements AppleKeyService {
      */
     public PrivateKey loadPrivateKey() {
         try {
-            String privateKeyPath = appleAuthConfig.getPrivateKeyPath();
-//            log.info("Private Key 파일 경로: {}", privateKeyPath);
-            byte[] keyBytes = Files.readAllBytes(Paths.get(privateKeyPath));
-            String privateKeyPEM = new String(keyBytes)
+            String privateKeyPEM = System.getenv("APPLE_PRIVATE_KEY");
+
+            if (privateKeyPEM == null) {
+                throw new RuntimeException("APPLE_PRIVATE_KEY 환경 변수가 설정되지 않았습니다.");
+            }
+
+            privateKeyPEM = privateKeyPEM
                     .replace("-----BEGIN PRIVATE KEY-----", "")
                     .replace("-----END PRIVATE KEY-----", "")
                     .replaceAll("\\s", "");
 
-//            log.info("Private Key (Base64): {}", privateKeyPEM);
+//            log.info("Apple Private Key: {}", privateKeyPEM);
 
-            byte[] decoded = Base64.getDecoder().decode(privateKeyPEM);
+            byte[] decoded = privateKeyPEM.getBytes();
             PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
             KeyFactory keyFactory = KeyFactory.getInstance("EC");
             return keyFactory.generatePrivate(keySpec);


### PR DESCRIPTION
# 🚀 개요
- secrets로부터 프로젝트 외부에 키파일을 생성하여 사용하는 방식 -> 환경변수로 사용하는 방식으로 변경
- 배포 서버에서 사용 시: Github secrets에 등록한 base64 인코딩된 파일을 cicd.yml 파일로 디코딩하여 사용
- 로컬 서버에서 사용 시: 인텔리제이 edit configurations 설정을 통해서 APPLE_PRIVATE_KEY라는 환경변수를 추가해주어야 함.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #156 

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
