### PR TITLE
[CI] 애플 시크릿 키파일 로드 방식 변경_3 #156

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,17 +40,12 @@ jobs:
           mkdir -p ./src/main/resources/firebase
           echo "${{ secrets.FIREBASE_ADMIN_SDK_BASE64 }}" | base64 -d > ./src/main/resources/firebase/puppymode-53d9a-firebase-adminsdk-myzbc-7e65f856a6.json
 
-      # Apple Private Key 파일 환경변수 load
-      - name: Set Apple Private Key as Environment Variable
-        run: echo "APPLE_PRIVATE_KEY=${{ secrets.APPLE_PRIVATE_KEY_BASE64 }}" >> $GITHUB_ENV
-        shell: bash
-
-
       # yml 파일 생성
       - name: Make application.yml
         run: |
           mkdir -p ./src/main/resources
           echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
+          echo "auth.apple.private-key=${{ secrets.APPLE_PRIVATE_KEY_BASE64 }}" >> ./src/main/resources/application.yml
         shell: bash
 
       # Spring Boot 어플리케이션 Build

--- a/src/main/java/umc/puppymode/config/AppleAuthConfig.java
+++ b/src/main/java/umc/puppymode/config/AppleAuthConfig.java
@@ -25,4 +25,7 @@ public class AppleAuthConfig {
 
     @Value("${auth.apple.key-id}")
     private String keyId;
+
+    @Value("${auth.apple.private-key}")
+    private String privateKey;
 }

--- a/src/main/java/umc/puppymode/service/AuthService/AppleKeyServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleKeyServiceImpl.java
@@ -91,16 +91,10 @@ public class AppleKeyServiceImpl implements AppleKeyService {
      */
     public PrivateKey loadPrivateKey() {
         try {
-            String base64PrivateKey = System.getenv("APPLE_PRIVATE_KEY");
-
-            if (base64PrivateKey == null) {
-                throw new RuntimeException("APPLE_PRIVATE_KEY 환경 변수가 설정되지 않았습니다.");
-            }
+            String privateKeyPath = appleAuthConfig.getPrivateKey();
 
             // Base64 디코딩
-            byte[] keyBytes = Base64.getDecoder().decode(base64PrivateKey);
-
-//            log.info("Apple Private Key: {}", privateKeyPEM);
+            byte[] keyBytes = Base64.getDecoder().decode(privateKeyPath);
 
             String privateKeyPEM = new String(keyBytes)
                     .replace("-----BEGIN PRIVATE KEY-----", "")


### PR DESCRIPTION
# 🚀 개요
- cicd.yml에서 관리되는 GITHUB_ENV는 파이프라인 이외의, 실제 프로젝트 코드에서는 접근 불가한 것으로 파악됨.
    -> 파이프라인에서 secrets의 인코딩된 AuthKey.p8을 application.yml의  값 내에 넣어주도록 설정

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #

## ⏳ 작업 내용
- 작업 내용 1
- 작업 내용 2
- 작업 내용 3

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
