### PR TITLE
[REFACTOR] 술약속 시작하기 API 위치 범위 넓히기 #176

### DIFF
--- a/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/LocationService/LocationServiceImpl.java
@@ -91,7 +91,7 @@ public class LocationServiceImpl implements LocationService {
                     userLatitude, userLongitude, targetLatitude, targetLongitude
             );
 
-            return distance <= 1.01; // 1km 이내 허용
+            return distance <= 5.01; // 1km 이내 허용
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.DISTANCE_CALCULATION_FAILED);
         }


### PR DESCRIPTION
# 🚀 개요
술약속 시작하기 API 위치 범위가 타이트해서 테스트에 어려움이 생기는 관계로, 범위를 조금 더 넓히도록 수정합니다.

## 📌 관련 이슈번호
- Closes #176 

## ⏳ 작업 내용
- 술약속 시작하기 API 위치 범위를 기존 반경 1km에서 5km로 조정
