### PR TITLE
[REFACTOR] 캘린더 조회 시 오늘 이후에 대한 status 수정 #179

### DIFF
--- a/src/main/java/umc/puppymode/service/CalendarService/CalendarQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/CalendarService/CalendarQueryServiceImpl.java
@@ -47,6 +47,7 @@ public class CalendarQueryServiceImpl implements CalendarQueryService{
         Map<LocalDate, CalendarListResponseDTO> drinkStatusMap = new HashMap<>();
         YearMonth targetMonth = YearMonth.parse(month);
         int lastDay = targetMonth.lengthOfMonth();
+        LocalDate today = LocalDate.now();
 
         for (DrinkHistory history : drinkHistories) {
             LocalDate date = history.getDrinkDate();
@@ -101,10 +102,17 @@ public class CalendarQueryServiceImpl implements CalendarQueryService{
 
         for (DrinkingAppointment appointment : appointments) {
             LocalDate date = appointment.getDateTime().toLocalDate();
+            String status;
+
+            if (date.isAfter(today)) {
+                status = "건강 챙기고 싶은 날";
+            } else {
+                status = "건강 포기한 날";
+            }
 
             drinkStatusMap.putIfAbsent(date, CalendarListResponseDTO.builder()
                     .drinkDate(date)
-                    .status("건강 포기한 날")
+                    .status(status)
                     .build());
 
             String appointmentTime = calculateAppointmentTime(appointment);
@@ -120,9 +128,16 @@ public class CalendarQueryServiceImpl implements CalendarQueryService{
         for (int day = 1; day <= lastDay; day++) {
             LocalDate date = LocalDate.of(targetMonth.getYear(), targetMonth.getMonth(), day);
             if (!drinkStatusMap.containsKey(date)) {
+                String status;
+                if (date.isAfter(today)) {
+                    status = "건강 챙기는 날";  // 오늘 이후이면서 약속이 없는 날
+                } else {
+                    status = "건강 챙긴 날";    // 오늘 이전이면서 기록이 없는 날
+                }
+
                 drinkStatusMap.put(date, CalendarListResponseDTO.builder()
                         .drinkDate(date)
-                        .status("건강 챙긴 날")
+                        .status(status)
                         .build());
             }
         }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
캘린더 조회 시 오늘 이후에 대한 status를 수정합니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #182 

## ⏳ 작업 내용
- 캘린더 조회 시 오늘 이후에 대한 status 수정
  - 건강 챙기는 날
  - 건강 챙기고 싶은 날

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
