### PR TITLE
[REFACTOR] 캘린더 조회 시 status가 오늘 날짜를 포함하여 나타나도록 수정 #184

### DIFF
--- a/src/main/java/umc/puppymode/service/CalendarService/CalendarQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/CalendarService/CalendarQueryServiceImpl.java
@@ -104,7 +104,7 @@ public class CalendarQueryServiceImpl implements CalendarQueryService{
             LocalDate date = appointment.getDateTime().toLocalDate();
             String status;
 
-            if (date.isAfter(today)) {
+            if (!date.isBefore(today)) {
                 status = "건강 챙기고 싶은 날";
             } else {
                 status = "건강 포기한 날";
@@ -129,8 +129,8 @@ public class CalendarQueryServiceImpl implements CalendarQueryService{
             LocalDate date = LocalDate.of(targetMonth.getYear(), targetMonth.getMonth(), day);
             if (!drinkStatusMap.containsKey(date)) {
                 String status;
-                if (date.isAfter(today)) {
-                    status = "건강 챙기는 날";  // 오늘 이후이면서 약속이 없는 날
+                if (!date.isBefore(today)) {
+                    status = "건강 챙기는 날";  // 오늘 포함 이후이면서 약속이 없는 날
                 } else {
                     status = "건강 챙긴 날";    // 오늘 이전이면서 기록이 없는 날
                 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
캘린더 조회 시 status가 오늘 날짜를 포함하여 나타나도록 수정 #184

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #184 

## ⏳ 작업 내용
- date.isAfter(today) → !date.isBefore(today)로 변경

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
