### PR TITLE
[REFACTOR] 앱 클라이언트에 맞게 수정 #163

### DIFF
--- a/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandServiceImpl.java
@@ -116,8 +116,7 @@ public class AppleAuthCommandServiceImpl implements AppleAuthCommandService {
             throw new RuntimeException("Client Secret 생성 실패" + e.getMessage(), e);
         }
 
-//        String clientId = appleAuthConfig.getClientId(); TODO: appleAuthConfig.getClientId() 로 변경
-        String clientId = "PuppyMode.umc.com";
+        String clientId = appleAuthConfig.getClientId();
         String redirectUri = appleAuthConfig.getRedirectUri();
 
 //        log.info("Apple Access Token 요청: client_id={}, code={}, grant_type={}, redirect_uri={}",
@@ -182,8 +181,7 @@ public class AppleAuthCommandServiceImpl implements AppleAuthCommandService {
                 throw new IllegalStateException("Private Key가 null 입니다. 초기화 순서를 확인하세요.");
             }
 
-//            String clientId = appleAuthConfig.getClientId(); TODO: appleAuthConfig.getClientId() 로 변경
-            String clientId = "PuppyMode.umc.com";
+            String clientId = appleAuthConfig.getClientId();
             String keyId = appleAuthConfig.getKeyId();
             String teamId = appleAuthConfig.getTeamId();
 

--- a/src/main/java/umc/puppymode/service/AuthService/AppleAuthQueryServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleAuthQueryServiceImpl.java
@@ -60,8 +60,8 @@ public class AppleAuthQueryServiceImpl implements AppleAuthQueryService {
                 throw new IllegalArgumentException("Invalid issuer: " + body.getIssuer());
             }
 
-            // aud(Audience) 검증 TODO: appleAuthConfig.getClientId() 로 변경
-            if (!"PuppyMode.umc.com".equals(body.getAudience())) {
+            // aud(Audience) 검증
+            if (!appleAuthConfig.getClientId().equals(body.getAudience())) {
                 throw new IllegalArgumentException("Invalid audience: " + body.getAudience());
             }
 

--- a/src/main/java/umc/puppymode/web/controller/AppleAuthController.java
+++ b/src/main/java/umc/puppymode/web/controller/AppleAuthController.java
@@ -28,7 +28,7 @@ public class AppleAuthController {
      * iOS 클라이언트용 애플 로그인 엔드포인트입니다.
      * JSON 요청을 받습니다.
      */
-//    @PostMapping("/login")
+    @PostMapping("/login")
     @Operation(summary = "애플 로그인 API",
             description = "애플 서버로부터 발급받은 `Authorization Token`과 `Identity Token`을 사용하여,  \n" +
                     "서버에서 JWT를 발급받는 API입니다.  \n" +
@@ -60,8 +60,7 @@ public class AppleAuthController {
      * 웹 테스트 용 애플 로그인 엔드포인트입니다.
      * form_post 요청을 받습니다.
      */
-//    @PostMapping("/web/callback")
-    @PostMapping("/login")
+    @PostMapping("/web/callback")
     @Operation(summary = "웹 테스트용 애플 로그인 API",
             description = "웹 방식으로 애플 로그인을 테스트합니다.")
     public ResponseEntity<ApiResponse<LoginResponseDTO>> appleWebLogin(

--- a/src/main/java/umc/puppymode/web/dto/AppleLoginRequestDTO.java
+++ b/src/main/java/umc/puppymode/web/dto/AppleLoginRequestDTO.java
@@ -1,5 +1,6 @@
 package umc.puppymode.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ public class AppleLoginRequestDTO {
     /**
      * username을 자동으로 생성합니다.
      */
+    @Schema(hidden = true)
     public String getUsername() {
         if (user == null || user.getName() == null) {
             return null;


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
웹 테스트용으로 임시 변경했던 코드를 앱 용으로 수정했습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #163

## ⏳ 작업 내용
- **`application.yml` 수정**
- controller 수정
- service 코드에서 client id 사용 부분을 앱 Id로 수정
- AppleLoginRequestDTO : 스웨거에서 username 필드 보이지 않도록 수정

### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- ~~애플 쪽에서 return url(웹용 엔드포인트 추가함) 반영이 며칠간 계속 안되고 있어서 앱 없이 테스트가 불가능 합니다.~~
    - 반영 되었습니다.
- 현재는 앱 없이 테스트 불가능합니다. (코드 수정해야 함)
    - 애플 return url에 보안상 로컬 등록이 불가능하여 배포 서버(https)로만 테스트가 가능합니다.
    - 웹 / 앱 각각 Service Id가 달라서 현재는 웹 테스트 시 코드 수정이 불가피합니다. 
    - application.yml에 두 개의 Service Id를 등록하는 방식으로 추가할 예정입니다.