### PR TITLE
[REFACTOR] 웹 애플 로그인 시 email 저장 로직 추가 #163

### DIFF
--- a/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandService.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandService.java
@@ -5,6 +5,10 @@ import umc.puppymode.web.dto.LoginResponseDTO;
 
 public interface AppleAuthCommandService {
     LoginResponseDTO loginWithApple(String authorizationCode, String identityToken, String username, String fcmToken);
+
+    LoginResponseDTO loginWithApple(String authorizationCode, String identityToken, String username, String email, String fcmToken);
+
     AppleTokenResponseDTO getAppleTokens(String authorizationCode);
+
     String generateClientSecret();
 }

--- a/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandServiceImpl.java
+++ b/src/main/java/umc/puppymode/service/AuthService/AppleAuthCommandServiceImpl.java
@@ -59,16 +59,26 @@ public class AppleAuthCommandServiceImpl implements AppleAuthCommandService {
      * @return 로그인 응답
      */
     @Override
-    public LoginResponseDTO loginWithApple(String authorizationCode, String identityToken, String username, String fcmToken) {
+    public LoginResponseDTO loginWithApple(String authorizationCode, String identityToken,
+                                           String username, String fcmToken) {
+        return loginWithApple(authorizationCode, identityToken, username, null, fcmToken);
+    }
+
+    @Override
+    public LoginResponseDTO loginWithApple(String authorizationCode, String identityToken, String username, String email, String fcmToken) {
 
         Claims claims = appleAuthQueryService.verifyIdentityToken(identityToken);
         if (claims == null) {
             throw new IllegalArgumentException("Invalid identity token");
         }
 
+        if (email == null) {
+            email = claims.get("email", String.class);
+        }
+
         UserAuthInfoDTO userInfo = UserAuthInfoDTO.builder()
                 .userAuthId(claims.getSubject())
-                .email(claims.get("email", String.class))
+                .email(email)
                 .authProvider(AuthProvider.APPLE)
                 .build();
 

--- a/src/main/java/umc/puppymode/web/controller/AppleAuthController.java
+++ b/src/main/java/umc/puppymode/web/controller/AppleAuthController.java
@@ -79,10 +79,12 @@ public class AppleAuthController {
             String userJson = formParams.get("user");
             String fcmToken = formParams.getOrDefault("fcm_token", null);
 
-            String username = extractUsername(userJson);
+            String[] userInfo = extractUserInfo(userJson);
+            String username = userInfo[0];
+            String email = userInfo[1];
 
             return ResponseEntity.ok(ApiResponse.onSuccess(
-                    processAppleLogin(authorizationCode, identityToken, username, fcmToken)
+                    processAppleLogin(authorizationCode, identityToken, username, email, fcmToken)
             ));
         } catch (IllegalArgumentException e) {
             log.warn("애플 로그인 유효성 오류: {}", e.getMessage());
@@ -96,41 +98,50 @@ public class AppleAuthController {
     }
 
     /**
-     * 애플 로그인 처리 공통 로직입니다.
+     * 애플 로그인 처리 공통 로직입니다. (앱 전용, email 없음)
      */
-    private LoginResponseDTO processAppleLogin(String authorizationCode, String identityToken, String username, String fcmToken) {
+    private LoginResponseDTO processAppleLogin(String authorizationCode, String identityToken,
+                                               String username, String fcmToken) {
         return appleAuthCommandService.loginWithApple(authorizationCode, identityToken, username, fcmToken);
+    }
+
+    /**
+     * 애플 로그인 처리 공통 로직입니다. (웹 전용, email 포함)
+     */
+    private LoginResponseDTO processAppleLogin(String authorizationCode, String identityToken,
+                                               String username, String email, String fcmToken) {
+        return appleAuthCommandService.loginWithApple(authorizationCode, identityToken, username, email, fcmToken);
     }
 
     /**
      * JSON에서 username(firstName + lastName)을 추출합니다.
      *
      * @param userJson
-     * @return username
+     * @return String[] (username, email)
      */
-    private String extractUsername(String userJson) {
+    private String[] extractUserInfo(String userJson) {
         if (userJson == null || userJson.isEmpty()) {
-            return null;
+            return new String[]{null, null};
         }
 
         try {
             JsonNode userNode = objectMapper.readTree(userJson);
             JsonNode nameNode = userNode.get("name");
-            if (nameNode == null) {
-                return null;
+            JsonNode emailNode = userNode.get("email");
+
+            String firstName = nameNode != null && nameNode.has("firstName") ? nameNode.get("firstName").asText() : "";
+            String lastName = nameNode != null && nameNode.has("lastName") ? nameNode.get("lastName").asText() : "";
+            String email = emailNode != null ? emailNode.asText() : null;
+
+            String username = (firstName + " " + lastName).trim();
+            if (username.isEmpty()) {
+                username = null;
             }
 
-            String firstName = nameNode.has("firstName") ? nameNode.get("firstName").asText() : "";
-            String lastName = nameNode.has("lastName") ? nameNode.get("lastName").asText() : "";
-
-            if (firstName.isEmpty() && lastName.isEmpty()) {
-                return null;
-            }
-
-            return (firstName + " " + lastName).trim();
+            return new String[]{username, email};
         } catch (Exception e) {
-            log.error("애플 로그인 사용자 이름 파싱 실패", e);
-            return null;
+            log.error("애플 로그인 사용자 정보 파싱 실패", e);
+            return new String[]{null, null};
         }
     }
 }


### PR DESCRIPTION
# 🚀 개요
<!-- 이 PR을 간략하게 설명해주세요 -->
웹 애플 로그인 시 email을 저장하는 로직을 추가했습니다.

## 📌 관련 이슈번호
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #163

## ⏳ 작업 내용
- controller, appleAuthCommandServiceImpl 수정